### PR TITLE
WIP: Use PackedCoordinateSequence

### DIFF
--- a/leaflet/index.html
+++ b/leaflet/index.html
@@ -1,0 +1,15 @@
+<html>
+<head>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.6.0/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@1.6.0/dist/leaflet.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/flatgeobuf@2.0.1/dist/flatgeobuf-geojson.min.js"></script>
+    
+    <style>
+        #mapid { height: 480px; }
+    </style>
+</head>
+<body>
+    <div id="mapid"></div>
+    <script src="index.js"></script>
+</body>
+</html>

--- a/leaflet/index.js
+++ b/leaflet/index.js
@@ -1,0 +1,25 @@
+// basic OSM Leaflet map
+let map = L.map('mapid').setView([41.505, -80.09], 4)
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    maxZoom: 19,
+    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+}).addTo(map)
+
+// handle ReadableStream response
+function handleResponse(response) {
+    // use flatgeobuf JavaScript API to iterate stream into results (features as geojson)
+    // NOTE: would be more efficient with a special purpose Leaflet deserializer
+    let it = flatgeobuf.deserializeStream(response.body)
+    // handle result
+    function handleResult(result) {
+        if (!result.done) {
+            L.geoJSON(result.value).addTo(map)
+            it.next().then(handleResult)
+        }
+    }
+    it.next().then(handleResult)
+}
+
+// using fetch API to get readable stream
+fetch('https://raw.githubusercontent.com/bjornharrtell/flatgeobuf/2.0.1/test/data/UScounties.fgb')
+    .then(handleResponse)

--- a/src/java/src/main/java/org/wololo/flatgeobuf/geotools/FeatureCollectionConversions.java
+++ b/src/java/src/main/java/org/wololo/flatgeobuf/geotools/FeatureCollectionConversions.java
@@ -24,11 +24,12 @@ public class FeatureCollectionConversions {
             return;
 
         SimpleFeatureType featureType = featureCollection.getSchema();
-        HeaderMeta headerMeta = FeatureTypeConversions.serialize(featureType, featuresCount, outputStream);
-
+        HeaderMeta headerMeta = null;
         try (FeatureIterator<SimpleFeature> iterator = featureCollection.features()) {
             while (iterator.hasNext()) {
                 SimpleFeature feature = iterator.next();
+                if (headerMeta == null)
+                    headerMeta = FeatureTypeConversions.serialize(featureType, feature, featuresCount, outputStream);
                 byte[] featureBuffer = FeatureConversions.serialize(feature, headerMeta);
                 outputStream.write(featureBuffer);
             }

--- a/src/java/src/main/java/org/wololo/flatgeobuf/geotools/FeatureConversions.java
+++ b/src/java/src/main/java/org/wololo/flatgeobuf/geotools/FeatureConversions.java
@@ -55,19 +55,19 @@ public class FeatureConversions {
             byte[] data = Arrays.copyOfRange(bb.array(), 0, bb.position());
             propertiesOffset = Feature.createPropertiesVector(builder, data);
         }
-        GeometryOffsets go = GeometryConversions.serialize(builder, geometry, headerMeta.geometryType);
+        GeometryOffsets go = GeometryConversions.serialize(builder, geometry, headerMeta.geometryType, headerMeta);
         int geometryOffset;
         if (go.gos != null) {
-        	int[] partOffsets = new int[go.gos.length];
-        	for (int i = 0; i < go.gos.length; i++) {
-        		GeometryOffsets goPart = go.gos[i];
-        		int partOffset = Geometry.createGeometry(builder, goPart.endsOffset,goPart.coordsOffset, 0, 0, 0, 0, 0, 0);
-        		partOffsets[i] = partOffset;
-        	}
-        	int partsOffset = Geometry.createPartsVector(builder, partOffsets);
-        	geometryOffset = Geometry.createGeometry(builder, 0, 0, 0, 0, 0, 0, 0, partsOffset);
+            int[] partOffsets = new int[go.gos.length];
+            for (int i = 0; i < go.gos.length; i++) {
+                GeometryOffsets goPart = go.gos[i];
+                int partOffset = Geometry.createGeometry(builder, goPart.endsOffset,goPart.xyOffset, goPart.zOffset, goPart.mOffset, 0, 0, 0, 0);
+                partOffsets[i] = partOffset;
+            }
+            int partsOffset = Geometry.createPartsVector(builder, partOffsets);
+            geometryOffset = Geometry.createGeometry(builder, 0, 0, 0, 0, 0, 0, 0, partsOffset);
         } else {
-        	geometryOffset = Geometry.createGeometry(builder, go.endsOffset, go.coordsOffset, 0, 0, 0, 0, 0, 0);
+            geometryOffset = Geometry.createGeometry(builder, go.endsOffset, go.xyOffset, go.zOffset, go.mOffset, 0, 0, 0, 0);
         }
         int featureOffset = Feature.createFeature(builder, geometryOffset, propertiesOffset, 0);
         builder.finishSizePrefixed(featureOffset);
@@ -84,8 +84,8 @@ public class FeatureConversions {
     }
 
     public static SimpleFeature deserialize(Feature feature, SimpleFeatureBuilder fb, HeaderMeta headerMeta) {
-    	Geometry geometry = feature.geometry();
-        fb.add(GeometryConversions.deserialize(geometry, headerMeta.geometryType));
+        Geometry geometry = feature.geometry();
+        fb.add(GeometryConversions.deserialize(geometry, headerMeta.geometryType, headerMeta));
         int propertiesLength = feature.propertiesLength();
         if (propertiesLength > 0) {
             ByteBuffer bb = feature.propertiesAsByteBuffer();

--- a/src/java/src/main/java/org/wololo/flatgeobuf/geotools/FeatureTypeConversions.java
+++ b/src/java/src/main/java/org/wololo/flatgeobuf/geotools/FeatureTypeConversions.java
@@ -61,12 +61,10 @@ public class FeatureTypeConversions {
             }
         }
 
-        // CoordinateReferenceSystem crs =
-        // featureType.getGeometryDescriptor().getCoordinateReferenceSystem();
+        // CoordinateReferenceSystem crs = featureType.getGeometryDescriptor().getCoordinateReferenceSystem();
         byte geometryType = GeometryConversions
                 .toGeometryType(featureType.getGeometryDescriptor().getType().getBinding());
-        // byte dimensions = (byte) (crs == null ? 2 :
-        // crs.getCoordinateSystem().getDimension());
+        // byte dimensions = (byte) (crs == null ? 2 : crs.getCoordinateSystem().getDimension());
 
         outputStream.write(Constants.MAGIC_BYTES);
 

--- a/src/java/src/main/java/org/wololo/flatgeobuf/geotools/GeometryConversions.java
+++ b/src/java/src/main/java/org/wololo/flatgeobuf/geotools/GeometryConversions.java
@@ -17,7 +17,6 @@ import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.LinearRing;
 import org.locationtech.jts.geom.MultiLineString;
 import org.locationtech.jts.geom.MultiPolygon;
-import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateSequence;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.impl.PackedCoordinateSequence;

--- a/src/java/src/main/java/org/wololo/flatgeobuf/geotools/GeometryConversions.java
+++ b/src/java/src/main/java/org/wololo/flatgeobuf/geotools/GeometryConversions.java
@@ -1,6 +1,7 @@
 package org.wololo.flatgeobuf.geotools;
 
 import java.io.IOException;
+import java.nio.DoubleBuffer;
 import java.util.stream.Stream;
 import java.util.Arrays;
 import java.util.function.IntFunction;
@@ -17,14 +18,16 @@ import org.locationtech.jts.geom.LinearRing;
 import org.locationtech.jts.geom.MultiLineString;
 import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateSequence;
 import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.impl.PackedCoordinateSequence;
 
 import org.wololo.flatgeobuf.generated.*;
 import org.wololo.flatgeobuf.generated.Geometry;
 
 public class GeometryConversions {
     public static GeometryOffsets serialize(FlatBufferBuilder builder, org.locationtech.jts.geom.Geometry geometry,
-    		byte geometryType) throws IOException {
+            byte geometryType, HeaderMeta headerMeta) throws IOException {
         GeometryOffsets go = new GeometryOffsets();
 
         if (geometryType == GeometryType.MultiLineString) {
@@ -43,60 +46,61 @@ public class GeometryConversions {
             for (int i = 0; i < p.getNumInteriorRing(); i++)
                 go.ends[i + 1] = end += p.getInteriorRingN(i).getNumPoints();
         } else if (geometryType == GeometryType.MultiPolygon) {
-        	MultiPolygon mp = (MultiPolygon) geometry;
-        	int numGeometries = mp.getNumGeometries();
-        	GeometryOffsets[] gos = new GeometryOffsets[numGeometries];
-        	for (int i = 0; i < numGeometries; i++) {
+            MultiPolygon mp = (MultiPolygon) geometry;
+            int numGeometries = mp.getNumGeometries();
+            GeometryOffsets[] gos = new GeometryOffsets[numGeometries];
+            for (int i = 0; i < numGeometries; i++) {
                 Polygon p = (Polygon) mp.getGeometryN(i);
-                gos[i] = serialize(builder, p, GeometryType.Polygon);
+                gos[i] = serialize(builder, p, GeometryType.Polygon, headerMeta);
             }
-        	go.gos = gos;
-        	return go;
+            go.gos = gos;
+            return go;
         }
-        
-        Stream<Coordinate> cs = Stream.of(geometry.getCoordinates());
-        double[] coords;
-        //if (headerMeta.hasZ && headerMeta.hasM)
-        //    coords = cs.flatMapToDouble(c -> DoubleStream.of(c.x, c.y, c.getZ(), c.getM())).toArray();
-        //else if (headerMeta.hasZ || headerMeta.hasM)
-        //    coords = cs.flatMapToDouble(c -> DoubleStream.of(c.x, c.y, c.getZ())).toArray();
-        //else
-            coords = cs.flatMapToDouble(c -> DoubleStream.of(c.x, c.y)).toArray();
-        go.coordsOffset = Geometry.createXyVector(builder, coords);
-        
+
+        go.xyOffset = Geometry.createXyVector(builder, Stream.of(geometry.getCoordinates()).flatMapToDouble(c -> DoubleStream.of(c.x, c.y)).toArray());
+        if (headerMeta.hasZ)
+            go.zOffset = Geometry.createZVector(builder, Stream.of(geometry.getCoordinates()).mapToDouble(c -> c.getZ()).toArray());
+        if (headerMeta.hasM)
+            go.mOffset = Geometry.createMVector(builder, Stream.of(geometry.getCoordinates()).mapToDouble(c -> c.getM()).toArray());
+
         if (go.ends != null)
             go.endsOffset = Geometry.createEndsVector(builder, go.ends);
 
         return go;
     }
 
-    public static org.locationtech.jts.geom.Geometry deserialize(Geometry geometry, byte geometryType) {
+    public static org.locationtech.jts.geom.Geometry deserialize(Geometry geometry, byte geometryType, HeaderMeta headerMeta) {
         GeometryFactory factory = new GeometryFactory();
         
         switch (geometryType) {
-    	case GeometryType.MultiPolygon:
-    		int partsLength = geometry.partsLength();
-    		Polygon[] polygons = new Polygon[partsLength];
-    		for (int i = 0; i < geometry.partsLength(); i++) {
-    			polygons[i] = (Polygon) deserialize(geometry.parts(i), GeometryType.Polygon);
-    		}
-    		return factory.createMultiPolygon(polygons);
-    	}
+        case GeometryType.MultiPolygon:
+            int partsLength = geometry.partsLength();
+            Polygon[] polygons = new Polygon[partsLength];
+            for (int i = 0; i < geometry.partsLength(); i++)
+                polygons[i] = (Polygon) deserialize(geometry.parts(i), GeometryType.Polygon, headerMeta);
+            return factory.createMultiPolygon(polygons);
+        }
         
-        
-        int xyLength = geometry.xyLength();
-        Coordinate[] coordinates = new Coordinate[xyLength >> 1];
-        int c = 0;
-        for (int i = 0; i < xyLength; i = i + 2)
-            coordinates[c++] = new Coordinate(geometry.xy(i), geometry.xy(i + 1));
+        int dim = 2; // check for z/t and increase accordingly
+        if (headerMeta.hasZ)
+            dim++;
+        int dimFinal = dim;
+        int measures = 0; // check for m and increase accordingly
+        int coordinateSize = dim + measures; // number of doubles per coordinate
+        DoubleBuffer coordinateDoubleBuffer = geometry.xyAsByteBuffer().asDoubleBuffer();
+        double[] coordinateDoubleArray = new double[coordinateDoubleBuffer.remaining()];
+        coordinateDoubleBuffer.get(coordinateDoubleArray);
+        CoordinateSequence coordinateSequence = new PackedCoordinateSequence.Double(coordinateDoubleArray, dim, measures);
 
         IntFunction<Polygon> makePolygonWithRings = (int endsLength) -> {
             LinearRing[] lrs = new LinearRing[endsLength];
             int s = 0;
             for (int i = 0; i < endsLength; i++) {
                 int e = (int) geometry.ends(i);
-                Coordinate[] cs = Arrays.copyOfRange(coordinates, s, e);
-                lrs[i] = factory.createLinearRing(cs);
+                CoordinateSequence partialCoordinateSequence = new PackedCoordinateSequence.Double(
+                        Arrays.copyOfRange(coordinateDoubleArray, s * coordinateSize, e * coordinateSize),
+                        dimFinal, measures);
+                lrs[i] = factory.createLinearRing(partialCoordinateSequence);
                 s = e;
             }
             LinearRing shell = lrs[0];
@@ -109,30 +113,31 @@ public class GeometryConversions {
             if (endsLength > 1)
                 return makePolygonWithRings.apply(endsLength);
             else
-                return factory.createPolygon(coordinates);
+                return factory.createPolygon(coordinateSequence);
         };
 
         switch (geometryType) {
         case GeometryType.Point:
-            if (coordinates.length > 0) {
-                return factory.createPoint(coordinates[0]);
-            } else {
+            if (coordinateSequence.size() > 0)
+                return factory.createPoint(coordinateSequence.getCoordinate(0));
+            else
                 return factory.createPoint();
-            }
         case GeometryType.MultiPoint:
-            return factory.createMultiPointFromCoords(coordinates);
+            return factory.createMultiPoint(coordinateSequence);
         case GeometryType.LineString:
-            return factory.createLineString(coordinates);
+            return factory.createLineString(coordinateSequence);
         case GeometryType.MultiLineString: {
             int lengthLengths = geometry.endsLength();
             if (lengthLengths < 2)
-                return factory.createMultiLineString(new LineString[] { factory.createLineString(coordinates) });
+                return factory.createMultiLineString(new LineString[] { factory.createLineString(coordinateSequence) });
             LineString[] lss = new LineString[lengthLengths];
             int s = 0;
             for (int i = 0; i < lengthLengths; i++) {
                 int e = (int) geometry.ends(i);
-                Coordinate[] cs = Arrays.copyOfRange(coordinates, s, e);
-                lss[i] = factory.createLineString(cs);
+                CoordinateSequence partialCoordinateSequence = new PackedCoordinateSequence.Double(
+                        Arrays.copyOfRange(coordinateDoubleArray, s * coordinateSize, e * coordinateSize),
+                        dim, measures);
+                lss[i] = factory.createLineString(partialCoordinateSequence);
                 s = e;
             }
             return factory.createMultiLineString(lss);

--- a/src/java/src/main/java/org/wololo/flatgeobuf/geotools/GeometryOffsets.java
+++ b/src/java/src/main/java/org/wololo/flatgeobuf/geotools/GeometryOffsets.java
@@ -1,10 +1,10 @@
 package org.wololo.flatgeobuf.geotools;
 
 public class GeometryOffsets {
-    int coordsOffset;
+    int xyOffset;
+    int zOffset;
+    int mOffset;
     public int[] ends = null;
-    public int[] lengths = null;
     public int endsOffset = 0;
-    public int lengthsOffset = 0;
     public GeometryOffsets[] gos = null;
 }

--- a/src/java/src/test/java/org/wololo/flatgeobuf/test/GeometryRoundtripTest.java
+++ b/src/java/src/test/java/org/wololo/flatgeobuf/test/GeometryRoundtripTest.java
@@ -101,6 +101,12 @@ public class GeometryRoundtripTest {
     }
 
     @Test
+    public void pointZ() throws IOException {
+        String expected = "POINT Z (1.2 -2.1 1)";
+        assertEquals(expected, roundTrip(expected));
+    }
+
+    @Test
     public void pointEmpty() throws IOException {
         String expected = "POINT EMPTY";
         assertEquals(expected, roundTrip(expected));

--- a/src/java/src/test/java/org/wololo/flatgeobuf/test/GeometryRoundtripTest.java
+++ b/src/java/src/test/java/org/wololo/flatgeobuf/test/GeometryRoundtripTest.java
@@ -90,7 +90,7 @@ public class GeometryRoundtripTest {
         bb.order(ByteOrder.LITTLE_ENDIAN);
         SimpleFeatureCollection fc = FeatureCollectionConversions.deserialize(bb);
         Geometry geometry = (Geometry) fc.features().next().getDefaultGeometry();
-        WKTWriter writer = new WKTWriter();
+        WKTWriter writer = new WKTWriter(4);
         return writer.write(geometry).replace('−', '-');
     }
 
@@ -102,7 +102,7 @@ public class GeometryRoundtripTest {
 
     @Test
     public void pointZ() throws IOException {
-        String expected = "POINT Z (1.2 -2.1 1)";
+        String expected = "POINT Z(1.2 -2.1 1)";
         assertEquals(expected, roundTrip(expected));
     }
 
@@ -131,6 +131,12 @@ public class GeometryRoundtripTest {
     }
 
     @Test
+    public void linestringZ() throws IOException {
+        String expected = "LINESTRING Z(1.2 -2.1 1, 2.4 -4.8 2)";
+        assertEquals(expected, roundTrip(expected));
+    }
+
+    @Test
     public void linestringEmpty() throws IOException {
         String expected = "LINESTRING EMPTY";
         assertEquals(expected, roundTrip(expected));
@@ -151,6 +157,12 @@ public class GeometryRoundtripTest {
     @Test
     public void polygon() throws IOException {
         String expected = "POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))";
+        assertEquals(expected, roundTrip(expected));
+    }
+
+    @Test
+    public void polygonZ() throws IOException {
+        String expected = "POLYGON Z((30 10 1, 40 40 1, 20 40 1, 10 20 1, 30 10 1))";
         assertEquals(expected, roundTrip(expected));
     }
 


### PR DESCRIPTION
Adaptation of https://github.com/bjornharrtell/flatgeobuf/pull/20.

Still working on Z/M support. It will not be optimal as PackedCoordinateSequence uses a single array whereas flatgeobuf has separate arrays for Z and M respectively.

NOTE: In the ecosystem we see this difference in memory layout of coordinate data and there seem to be no consesus. Fx. JTS and OpenLayers have a single array with dimension as stride where as GDAL and QGIS keep the additional dimensions as separate arrays.