### PR TITLE
For the Rust crate, disable default features of reqwest. It brings in

### DIFF
--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flatgeobuf"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Pirmin Kalberer <pka@sourcepole.ch>"]
 edition = "2018"
 description = "FlatGeobuf for Rust."

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -16,7 +16,7 @@ flatbuffers = "0.6"
 byteorder = "1.4.2"
 geozero = "0.6.0"
 async-trait = "0.1.42"
-reqwest = "0.11.0"
+reqwest = { version = "0.11.0", default-features = false }
 bytes = "1.0.1"
 log = "0.4.13"
 fallible-streaming-iterator = "0.1.9"
@@ -28,6 +28,8 @@ hex = "0.4.2"
 criterion = "0.3.3"
 tempfile = "3.2.0"
 tokio = { version = "1.0.2", default-features = false, features = ["rt-multi-thread"] }
+# One test needs SSL support; just use the default system bindings for that.
+reqwest = { version = "0.11.0", default-features = true }
 
 [[bench]]
 name = "read"


### PR DESCRIPTION
system bindings to SSL, which are undesirable for some users. Since
features are additive, this frees up callers to make the choice instead.

This is for a-b-street/abstreet/issues/519