### PR TITLE
Make http an optional feature

### DIFF
--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -11,13 +11,17 @@ documentation = "https://docs.rs/flatgeobuf/"
 license = "ISC"
 keywords = ["geo", "r-tree", "spatial"]
 
+[features]
+default = ["http"]
+http = ["reqwest", "async-trait", "bytes"]
+
 [dependencies]
 flatbuffers = "0.6"
 byteorder = "1.4.2"
 geozero = "0.6.0"
-async-trait = "0.1.42"
-reqwest = { version = "0.11.0", default-features = false }
-bytes = "1.0.1"
+async-trait = { version = "0.1.42", optional = true }
+reqwest = { version = "0.11.0", default-features = false, optional = true }
+bytes = { version = "1.0.1", optional = true }
 log = "0.4.13"
 fallible-streaming-iterator = "0.1.9"
 
@@ -41,3 +45,7 @@ harness = false
 #[patch.crates-io]
 # Patch geozero dependencies (dev only)
 #geozero = { path = "../../../../rust/geozero/geozero" }
+
+[package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -97,6 +97,7 @@
 //! ```rust
 //! use flatgeobuf::*;
 //!
+//! #[cfg(feature = "http")]
 //! # async fn read_fbg() -> geozero::error::Result<()> {
 //! let mut fgb = HttpFgbReader::open("https://pkg.sourcepole.ch/countries.fgb").await?;
 //! fgb.select_bbox(8.8, 47.2, 9.5, 55.3).await?;
@@ -109,6 +110,7 @@
 //! ```
 //!
 
+#[cfg(feature = "http")]
 #[macro_use]
 extern crate log;
 
@@ -120,18 +122,24 @@ mod file_reader;
 mod geometry_reader;
 #[allow(dead_code, unused_imports, non_snake_case)]
 mod header_generated;
+#[cfg(feature = "http")]
 mod http_client;
+#[cfg(feature = "http")]
 mod http_reader;
 mod packed_r_tree;
 mod properties_reader;
 
+#[cfg(all(feature = "http", not(target_arch = "wasm32")))]
+pub use driver::http::*;
 #[cfg(not(target_arch = "wasm32"))]
 pub use driver::*;
 pub use feature_generated::flat_geobuf::*;
 pub use file_reader::*;
 pub use geometry_reader::*;
 pub use header_generated::flat_geobuf::*;
+#[cfg(feature = "http")]
 pub use http_client::*;
+#[cfg(feature = "http")]
 pub use http_reader::*;
 pub use packed_r_tree::*;
 pub use properties_reader::*;

--- a/src/rust/src/packed_r_tree.rs
+++ b/src/rust/src/packed_r_tree.rs
@@ -1,10 +1,11 @@
 //! Create and read a [packed Hilbert R-Tree](https://en.wikipedia.org/wiki/Hilbert_R-tree#Packed_Hilbert_R-trees)
 //! to enable fast bounding box spatial filtering.
 
+#[cfg(feature = "http")]
 use crate::http_client::BufferedHttpRangeClient;
 use geozero::error::{GeozeroError, Result};
 use std::cmp::Reverse;
-use std::collections::{BinaryHeap, HashMap, VecDeque};
+use std::collections::{BinaryHeap, HashMap};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::mem::size_of;
 use std::{cmp, f64, u64, usize};
@@ -124,6 +125,7 @@ fn read_node_items<R: Read + Seek>(
 }
 
 /// Read partial item vec from http
+#[cfg(feature = "http")]
 async fn read_http_node_items(
     client: &mut BufferedHttpRangeClient,
     min_req_size: usize,
@@ -353,6 +355,7 @@ impl PackedRTree {
         Ok(())
     }
 
+    #[cfg(feature = "http")]
     async fn read_http(
         &mut self,
         client: &mut BufferedHttpRangeClient,
@@ -406,6 +409,7 @@ impl PackedRTree {
         Ok(tree)
     }
 
+    #[cfg(feature = "http")]
     pub async fn from_http(
         client: &mut BufferedHttpRangeClient,
         index_begin: usize,
@@ -526,6 +530,7 @@ impl PackedRTree {
         Ok(results)
     }
 
+    #[cfg(feature = "http")]
     pub async fn http_stream_search(
         client: &mut BufferedHttpRangeClient,
         index_begin: usize,
@@ -536,6 +541,8 @@ impl PackedRTree {
         max_x: f64,
         max_y: f64,
     ) -> Result<Vec<SearchResultItem>> {
+        use std::collections::VecDeque;
+
         let item = NodeItem::new(min_x, min_y, max_x, max_y);
         let level_bounds = PackedRTree::generate_level_bounds(num_items, node_size);
         let leaf_nodes_offset = level_bounds.first().ok_or(GeozeroError::GeometryIndex)?.0;

--- a/src/rust/tests/geojson.rs
+++ b/src/rust/tests/geojson.rs
@@ -40,6 +40,7 @@ fn num_properties() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "http")]
 async fn http_json_async() -> Result<()> {
     let url = "https://github.com/flatgeobuf/flatgeobuf/raw/master/test/data/countries.fgb";
     let mut fgb = HttpFgbReader::open(url).await?;
@@ -59,6 +60,7 @@ async fn http_json_async() -> Result<()> {
 }
 
 #[test]
+#[cfg(feature = "http")]
 fn http_json() {
     assert!(tokio::runtime::Runtime::new()
         .unwrap()

--- a/src/rust/tests/http_read.rs
+++ b/src/rust/tests/http_read.rs
@@ -1,84 +1,88 @@
-use flatgeobuf::*;
-use geozero::error::Result;
-use tokio::runtime::Runtime;
+#[cfg(feature = "http")]
+mod http {
 
-async fn http_read_async() -> Result<()> {
-    let url = "https://github.com/flatgeobuf/flatgeobuf/raw/master/test/data/countries.fgb";
-    let mut fgb = HttpFgbReader::open(url).await?;
-    assert_eq!(fgb.header().geometry_type(), GeometryType::MultiPolygon);
-    assert_eq!(fgb.header().features_count(), 179);
-    fgb.select_all().await?;
-    let feature = fgb.next().await?.unwrap();
-    let props = feature.properties()?;
-    assert_eq!(props["name"], "Antarctica".to_string());
-    Ok(())
-}
+    use flatgeobuf::*;
+    use geozero::error::Result;
+    use tokio::runtime::Runtime;
 
-#[test]
-fn http_read() {
-    assert!(Runtime::new().unwrap().block_on(http_read_async()).is_ok());
-}
+    async fn http_read_async() -> Result<()> {
+        let url = "https://github.com/flatgeobuf/flatgeobuf/raw/master/test/data/countries.fgb";
+        let mut fgb = HttpFgbReader::open(url).await?;
+        assert_eq!(fgb.header().geometry_type(), GeometryType::MultiPolygon);
+        assert_eq!(fgb.header().features_count(), 179);
+        fgb.select_all().await?;
+        let feature = fgb.next().await?.unwrap();
+        let props = feature.properties()?;
+        assert_eq!(props["name"], "Antarctica".to_string());
+        Ok(())
+    }
 
-async fn http_bbox_read_async() -> Result<()> {
-    let url = "https://github.com/flatgeobuf/flatgeobuf/raw/master/test/data/countries.fgb";
-    let mut fgb = HttpFgbReader::open(url).await?;
-    assert_eq!(fgb.header().geometry_type(), GeometryType::MultiPolygon);
-    assert_eq!(fgb.header().features_count(), 179);
-    fgb.select_bbox(8.8, 47.2, 9.5, 55.3).await?;
-    let feature = fgb.next().await?.unwrap();
-    let props = feature.properties()?;
-    assert_eq!(props["name"], "Denmark".to_string());
-    Ok(())
-}
+    #[test]
+    fn http_read() {
+        assert!(Runtime::new().unwrap().block_on(http_read_async()).is_ok());
+    }
 
-#[test]
-fn http_bbox_read() {
-    assert!(Runtime::new()
-        .unwrap()
-        .block_on(http_bbox_read_async())
-        .is_ok());
-}
+    async fn http_bbox_read_async() -> Result<()> {
+        let url = "https://github.com/flatgeobuf/flatgeobuf/raw/master/test/data/countries.fgb";
+        let mut fgb = HttpFgbReader::open(url).await?;
+        assert_eq!(fgb.header().geometry_type(), GeometryType::MultiPolygon);
+        assert_eq!(fgb.header().features_count(), 179);
+        fgb.select_bbox(8.8, 47.2, 9.5, 55.3).await?;
+        let feature = fgb.next().await?.unwrap();
+        let props = feature.properties()?;
+        assert_eq!(props["name"], "Denmark".to_string());
+        Ok(())
+    }
 
-async fn http_bbox_big_async() -> Result<()> {
-    let url = "https://pkg.sourcepole.ch/osm-buildings-ch.fgb";
-    let mut fgb = HttpFgbReader::open(url).await?;
-    assert_eq!(fgb.header().geometry_type(), GeometryType::MultiPolygon);
-    assert_eq!(fgb.header().features_count(), 2396905);
-    fgb.select_bbox(8.522086, 47.363333, 8.553521, 47.376020)
-        .await?;
-    let feature = fgb.next().await?.unwrap();
-    let props = feature.properties()?;
-    assert_eq!(props["building"], "residential".to_string());
-    Ok(())
-}
+    #[test]
+    fn http_bbox_read() {
+        assert!(Runtime::new()
+            .unwrap()
+            .block_on(http_bbox_read_async())
+            .is_ok());
+    }
 
-#[test]
-#[ignore]
-fn http_bbox_big() {
-    assert!(Runtime::new()
-        .unwrap()
-        .block_on(http_bbox_big_async())
-        .is_ok());
-}
+    async fn http_bbox_big_async() -> Result<()> {
+        let url = "https://pkg.sourcepole.ch/osm-buildings-ch.fgb";
+        let mut fgb = HttpFgbReader::open(url).await?;
+        assert_eq!(fgb.header().geometry_type(), GeometryType::MultiPolygon);
+        assert_eq!(fgb.header().features_count(), 2396905);
+        fgb.select_bbox(8.522086, 47.363333, 8.553521, 47.376020)
+            .await?;
+        let feature = fgb.next().await?.unwrap();
+        let props = feature.properties()?;
+        assert_eq!(props["building"], "residential".to_string());
+        Ok(())
+    }
 
-async fn http_err_async() {
-    let url = "https://github.com/flatgeobuf/flatgeobuf/raw/master/test/data/wrong.fgb";
-    let fgb = HttpFgbReader::open(url).await;
-    assert_eq!(
-        fgb.err().unwrap().to_string(),
-        "http status 404".to_string()
-    );
-    let url = "http://wrong.sourcepole.ch/countries.fgb";
-    let fgb = HttpFgbReader::open(url).await;
-    let error_text = fgb.err().unwrap().to_string();
-    let expected_error_text = "error trying to connect";
-    assert!(
-        error_text.contains(expected_error_text),
-        format!("expected to find {} in {}", expected_error_text, error_text)
-    );
-}
+    #[test]
+    #[ignore]
+    fn http_bbox_big() {
+        assert!(Runtime::new()
+            .unwrap()
+            .block_on(http_bbox_big_async())
+            .is_ok());
+    }
 
-#[test]
-fn http_err() {
-    Runtime::new().unwrap().block_on(http_err_async());
+    async fn http_err_async() {
+        let url = "https://github.com/flatgeobuf/flatgeobuf/raw/master/test/data/wrong.fgb";
+        let fgb = HttpFgbReader::open(url).await;
+        assert_eq!(
+            fgb.err().unwrap().to_string(),
+            "http status 404".to_string()
+        );
+        let url = "http://wrong.sourcepole.ch/countries.fgb";
+        let fgb = HttpFgbReader::open(url).await;
+        let error_text = fgb.err().unwrap().to_string();
+        let expected_error_text = "error trying to connect";
+        assert!(
+            error_text.contains(expected_error_text),
+            format!("expected to find {} in {}", expected_error_text, error_text)
+        );
+    }
+
+    #[test]
+    fn http_err() {
+        Runtime::new().unwrap().block_on(http_err_async());
+    }
 }

--- a/src/rust/tests/svg.rs
+++ b/src/rust/tests/svg.rs
@@ -34,7 +34,7 @@ fn svg_writer<'a, W: Write>(
     svg
 }
 
-trait GeomToGeoJson {
+trait GeomToSvg {
     fn to_svg<'a, W: Write>(
         &self,
         out: &'a mut W,
@@ -43,7 +43,7 @@ trait GeomToGeoJson {
     ) -> Result<()>;
 }
 
-impl GeomToGeoJson for Geometry<'_> {
+impl GeomToSvg for Geometry<'_> {
     fn to_svg<'a, W: Write>(
         &self,
         out: &'a mut W,
@@ -55,7 +55,7 @@ impl GeomToGeoJson for Geometry<'_> {
     }
 }
 
-trait FeatureToGeoJson {
+trait FeatureToSvg {
     fn to_svg<'a, W: Write>(
         &self,
         out: &'a mut W,
@@ -64,7 +64,7 @@ trait FeatureToGeoJson {
     ) -> Result<()>;
 }
 
-impl FeatureToGeoJson for Feature<'_> {
+impl FeatureToSvg for Feature<'_> {
     /// Convert feature to SVG
     fn to_svg<'a, W: Write>(
         &self,
@@ -124,6 +124,7 @@ fn fgb_to_svg() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "http")]
 async fn http_svg_async() -> Result<()> {
     let url = "https://github.com/flatgeobuf/flatgeobuf/raw/master/test/data/countries.fgb";
     let mut fgb = HttpFgbReader::open(url).await?;
@@ -144,6 +145,7 @@ async fn http_svg_async() -> Result<()> {
 }
 
 #[test]
+#[cfg(feature = "http")]
 fn http_svg() {
     assert!(tokio::runtime::Runtime::new()
         .unwrap()


### PR DESCRIPTION
Dependency tree without http feature:

```
$ cargo tree --no-default-features --edges no-dev
flatgeobuf v0.5.0 (/home/pi/code/gis/flatgeobuf/src/rust)
├── byteorder v1.4.2
├── fallible-streaming-iterator v0.1.9
├── flatbuffers v0.6.1
│   └── smallvec v1.6.1
├── geozero v0.6.0
│   ├── async-trait v0.1.42 (proc-macro)
│   │   ├── proc-macro2 v1.0.24
│   │   │   └── unicode-xid v0.2.1
│   │   ├── quote v1.0.9
│   │   │   └── proc-macro2 v1.0.24 (*)
│   │   └── syn v1.0.60
│   │       ├── proc-macro2 v1.0.24 (*)
│   │       ├── quote v1.0.9 (*)
│   │       └── unicode-xid v0.2.1
│   ├── seek_bufread v1.2.2
│   └── thiserror v1.0.23
│       └── thiserror-impl v1.0.23 (proc-macro)
│           ├── proc-macro2 v1.0.24 (*)
│           ├── quote v1.0.9 (*)
│           └── syn v1.0.60 (*)
└── log v0.4.14
    └── cfg-if v1.0.0
```