### PR TITLE
Java serialization: memory and speed improvements

### DIFF
--- a/src/java/pom.xml
+++ b/src/java/pom.xml
@@ -92,6 +92,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.2.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -100,6 +101,15 @@
             </goals>
           </execution>
         </executions>
+        <configuration>
+          <tags>
+            <tag>
+              <name>implNote</name>
+              <placement>a</placement>
+              <head>Implementation Note:</head>
+            </tag>
+          </tags>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/java/src/main/java/org/wololo/flatgeobuf/geotools/FeatureCollectionConversions.java
+++ b/src/java/src/main/java/org/wololo/flatgeobuf/geotools/FeatureCollectionConversions.java
@@ -27,8 +27,7 @@ public class FeatureCollectionConversions {
         try (FeatureIterator<SimpleFeature> iterator = featureCollection.features()) {
             while (iterator.hasNext()) {
                 SimpleFeature feature = iterator.next();
-                byte[] featureBuffer = FeatureConversions.serialize(feature, headerMeta);
-                outputStream.write(featureBuffer);
+                FeatureConversions.serialize(feature, headerMeta, outputStream);
             }
         }
     }

--- a/src/java/src/main/java/org/wololo/flatgeobuf/geotools/FlatBuffers.java
+++ b/src/java/src/main/java/org/wololo/flatgeobuf/geotools/FlatBuffers.java
@@ -1,0 +1,74 @@
+package org.wololo.flatgeobuf.geotools;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import org.geotools.util.NIOUtilities;
+import com.google.flatbuffers.FlatBufferBuilder;
+import com.google.flatbuffers.FlatBufferBuilder.ByteBufferFactory;
+
+/**
+ * Utility class to create and release the internal byte buffers of a {@link FlatBufferBuilder}.
+ * <p>
+ * In order to either release or return to the cache the used buffers as soon as possible, use
+ * {@link #newBuilder(int)} and {@link #release(FlatBufferBuilder)} as soon as possible, instead of
+ * expecting the GC to do it.
+ * 
+ * @implNote Currently, the returned {@link FlatBufferBuilder builders} use a
+ *           {@link ByteBufferFactory} that uses GeoTools {@link NIOUtilities} cached buffers. This
+ *           means that the buffers will be reused, but also that they'll be direct or heap buffers
+ *           depending on {@link NIOUtilities#isDirectBuffersEnabled()}, hence the importance of
+ *           calling {@link #release(FlatBufferBuilder)} as soon as the builder is to be disposed,
+ *           to the GeoTools utility can take care of cleaning up the direct buffers when needed.
+ */
+public class FlatBuffers {
+
+    private static class ReleasingByteBufferFactory extends ByteBufferFactory {
+
+        private ByteBuffer lastBuffer;
+
+        @Override
+        public ByteBuffer newByteBuffer(int capacity) {
+            ByteBuffer buff = NIOUtilities.allocate(capacity);
+            buff.order(ByteOrder.LITTLE_ENDIAN);
+            lastBuffer = buff;
+            return lastBuffer;
+        }
+
+        @Override
+        public void releaseByteBuffer(ByteBuffer bb) {
+            NIOUtilities.returnToCache(bb);
+        }
+
+        public void release() {
+            if (lastBuffer != null) {
+                releaseByteBuffer(lastBuffer);
+                lastBuffer = null;
+            }
+        }
+    };
+
+    private static class ReleasingFlatBufferBuilder extends FlatBufferBuilder {
+
+        private ReleasingByteBufferFactory factory;
+
+        public ReleasingFlatBufferBuilder(int initialSize, ReleasingByteBufferFactory factory) {
+            super(initialSize, factory);
+            this.factory = factory;
+        }
+
+        public void releaseBuffer() {
+            factory.release();
+        }
+
+    }
+
+    public static FlatBufferBuilder newBuilder(int minimumCapacity) {
+        return new ReleasingFlatBufferBuilder(minimumCapacity, new ReleasingByteBufferFactory());
+    }
+
+    public static void release(FlatBufferBuilder builder) {
+        if (builder instanceof ReleasingFlatBufferBuilder) {
+            ((ReleasingFlatBufferBuilder) builder).releaseBuffer();
+        }
+    }
+}

--- a/src/java/src/test/java/org/wololo/flatgeobuf/test/GeometryRoundtripTest.java
+++ b/src/java/src/test/java/org/wololo/flatgeobuf/test/GeometryRoundtripTest.java
@@ -129,7 +129,7 @@ public class GeometryRoundtripTest {
 
     @Test
     public void multilinestring() throws IOException {
-        String expected = "MULTILINESTRING ((10 10, 20 20, 10 40), (40 40, 30 30, 40 20, 30 10))";
+        String expected = "MULTILINESTRING ((1 2, 3 4, 5 6), (7 8, 9 10, 11 12, 13 14))";
         assertEquals(expected, roundTrip(expected));
     }
 


### PR DESCRIPTION
Hi all,

I've been testing the GeoServer WFS output format with the docker composition from https://github.com/camptocamp/geoserver-cloud.

Had the WFS containers capped at 2 CPUs with 1GB of RAM with 80% available to the JVM, and they were exiting with OOM.

So increased the container memory to 2GB with 50% for the JVM, and noticed there's still quite a spike in memory consumption.

Put hands-on and got these improvements, that reduce the memory footprint of Java serialization and increases the throughput.

The commit messages should be informative enough of what's going on, so I won't repeat here.

Bottom line, here are some results:

|   | Max Throughput (reqs/s) | Memory | Memory Delta (*) |
| ------------- | ------------- | ----------- | ----------- |
| GML2 Baseline | ~530  | ~700 | ~200 |
| FBS Baseline  | ~130  | +1.2GiB | ~700 |
| FBS Improvements  | > 1000  | ~600 | ~100 |

> (*) Taking into account that the initial memory usage is around 500MiB (container memory, doesn't mean it's all JVM's Heap)

That's close to an order of magnitude in performance, at about 1/7 of memory footprint.

Here are some screencasts of what it looks like. 
The top half of the screen shows the output of `docker stats`, watch out the `MEM USAGE / LIMIT` columns for the `gs_cloud_wfs_X` containers as I run these simple tests:

`test_gml2.sh`:
```bash
#!/bin/bash
fbs="http://localhost:9090/wfs?request=GetFeature&typeName=topp:states&outputFormat=gml2"
for i in 2 4 8 16 32; do echo "Concurrency: $i" && ab -t 3 -c $i "$fbs" 2>/dev/null|grep -e "Requests per second";done
```

`test_fbs.sh`:
```bash
#!/bin/bash
fbs="http://localhost:9090/wfs?request=GetFeature&typeName=topp:states&outputFormat=application/flatgeobuf"
for i in 2 4 8 16 32; do echo "Concurrency: $i" && ab -t 3 -c $i "$fbs" 2>/dev/null|grep -e "Requests per second";done
```

## GML Baseline

https://user-images.githubusercontent.com/207423/109921883-4b4c5180-7c9b-11eb-8b51-c77ff8998a6a.mp4
> GML2 baseline (fastest GML encoder in GeoServer)

## FlatGeoBuff Baseline

https://user-images.githubusercontent.com/207423/109923853-29080300-7c9e-11eb-9505-22b89342c5cb.mp4
> FlatGeoBuff baseline (master at f08c2138bf5bb89e2316fc70c7f07f0a5f64ff96)

## FlatGeoBuff Improvements

https://user-images.githubusercontent.com/207423/109922302-e2190e00-7c9b-11eb-891c-e2c6b5f0bcb5.mp4
> FlatGeoBuff improvements (this PR at 6f0732cf1ee5c816f8a7dcc34bebc2b9db49b2b8)

---
Although I didn't write new unit tests, all existing ones pass, and I've checked the output of GeoServer is exactly the same as the baseline's.



