### PR TITLE
java: write layer name

### DIFF
--- a/src/java/src/main/java/org/wololo/flatgeobuf/HeaderMeta.java
+++ b/src/java/src/main/java/org/wololo/flatgeobuf/HeaderMeta.java
@@ -44,6 +44,10 @@ public class HeaderMeta {
         }).toArray();
         int columnsOffset = Header.createColumnsVector(builder, columnsArray);
 
+        int nameOffset = 0;
+        if (headerMeta.name!=null) {
+            nameOffset = builder.createString(headerMeta.name);
+        }
         int crsOffset = 0;
         if (headerMeta.srid != 0) {
             Crs.startCrs(builder);
@@ -54,6 +58,7 @@ public class HeaderMeta {
         Header.addGeometryType(builder, headerMeta.geometryType);
         Header.addIndexNodeSize(builder, 0);
         Header.addColumns(builder, columnsOffset);
+        Header.addName(builder, nameOffset);
         Header.addCrs(builder, crsOffset);
         Header.addFeaturesCount(builder, headerMeta.featuresCount);
         int offset = Header.endHeader(builder);


### PR DESCRIPTION
It seems as if the name is set in the header, the name is not written and `ogrinfo` always shows "unknown".