### PR TITLE
fix path to fgb in example

### DIFF
--- a/examples/leaflet/index_filtered.js
+++ b/examples/leaflet/index_filtered.js
@@ -23,7 +23,7 @@ const rect = {
 
 // use flatgeobuf JavaScript API to iterate stream into results (features as geojson)
 // NOTE: would be more efficient with a special purpose Leaflet deserializer
-let it = flatgeobuf.deserialize('UScounties.fgb', rect, handleHeaderMeta)
+let it = flatgeobuf.deserialize('/test/data/UScounties.fgb', rect, handleHeaderMeta)
 // handle result
 function handleResult(result) {
     if (!result.done) {


### PR DESCRIPTION
https://flatgeobuf.org/examples/leaflet/index_filtered.html currently 404's when fetching the fgb. 

This should fix it. I tested that /examples/leaflet/index.html and /examples/leaflet/index_filtered.html both work locally after this change.

