### PR TITLE
js: don't delay initial request.

### DIFF
--- a/examples/leaflet/filtered.html
+++ b/examples/leaflet/filtered.html
@@ -101,7 +101,7 @@
                 }
             }
             // if the user is panning around alot, only update once per second max
-            updateResults = _.debounce(updateResults, 1000);
+            updateResults = _.throttle(updateResults, 1000);
 
             // show a leaflet rect corresponding to our bounding box
             let rectangle = L.rectangle(getBoundForRect(), { color: "yellow", fillOpacity: 0.7, opacity: 1.0 }).addTo(map);

--- a/examples/leaflet/large.html
+++ b/examples/leaflet/large.html
@@ -102,7 +102,7 @@
                 }
             }
             // if the user is panning around alot, only update once per second max
-            updateResults = _.debounce(updateResults, 1000);
+            updateResults = _.throttle(updateResults, 1000);
 
             // show a leaflet rect corresponding to our bounding box
             let rectangle = L.rectangle(getBoundForRect(), { color: "yellow", fillOpacity: 0.7, opacity: 1.0 }).addTo(map);


### PR DESCRIPTION
I injected a needless 1s of latency into filtering the examples from using `debounce` instead of `throttle`.

`throttle` will execute immediately the first event, but delays
subsequent events within it's timeout, whereas `debounce` will
always wait for the `timeout` since _last_ event.

