### PR TITLE
document CDN recommendations for faster spatial filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,30 @@ As performance is highly data dependent I've also made similar tests on a larger
 | Write w/spatial index | 1         | 1.07       | 0.70       |
 | Size                  | 1         | 0.77       | 0.95       |
 
+### Optimizing Remotely Hosted FlatGeobufs
+
+If you're accessing a FlatGeobuf file over HTTP, consider using a CDN to
+minimize latency.
+
+In particular, when [using the spatial
+filter](https://flatgeobuf.org/examples/leaflet/filtered.html) to get a subset
+of features, multiple requests will be made. Often round-trip latency, rather
+than throughput, is the limiting factor. A caching CDN can be especially
+helpful here.
+
+Fetching a subset of a file over HTTP utilizes Range requests. If the page
+accessing the FGB is hosted on a different domain from the CDN, [Cross
+Origin](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) policy
+applies, and the required `Range` header will induce an `OPTIONS` (preflight)
+request.
+
+Popular CDNs, like Cloudfront, support Range Requests, but don't cache the
+requisite preflight OPTIONS requests by default. Consider [enabling OPTIONS
+request caching
+](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/header-caching.html#header-caching-web-cors).
+Without this, the preflight authorization request could be much slower than
+necessary.
+
 ## Features
 
 * Reference implementation for JavaScript, TypeScript, C++, C#, Java and Rust


### PR DESCRIPTION
This is kind of a strange PR - primarily I'm asking you to click this button in your cloudfront distribution so our examples can run faster:

![cache-options](https://user-images.githubusercontent.com/217057/121592977-37c62a80-c9f0-11eb-97d1-be2fb6dfd4b9.png)

But also, I thought it might make sense to document this somewhere for other folks, since it makes a huge difference.

I noted in https://github.com/flatgeobuf/flatgeobuf/issues/122#issuecomment-844546775 an inordinate delay between the 1st and 2nd requests, greater than all the other requests combined:

(screenshot from safari)
![image](https://user-images.githubusercontent.com/217057/121591063-eae15480-c9ed-11eb-87a4-0e311f8ab772.png)
Apparently the safari devtools has [a bug that greatly confuses the display of preflight (OPTION) requests](https://bugs.webkit.org/show_bug.cgi?id=213215). 

So let's look at Chrome, which makes it much clearer that we're waiting a long time for preflight OPTIONS request:
<img width="1215" alt="Screen Shot 2021-06-10 at 11 24 17 AM" src="https://user-images.githubusercontent.com/217057/121590704-7c03fb80-c9ed-11eb-9700-315a2035f24a.png">

Browsers typically enforce a very short TTL for caching OPTIONS requests, so even subsequent requests still pay the OPTIONS tax (while caching the GETs):
<img width="1218" alt="Screen Shot 2021-06-10 at 11 38 58 AM" src="https://user-images.githubusercontent.com/217057/121591295-2aa83c00-c9ee-11eb-8a3a-5ed8ead5c05d.png">

So we can't rely on the browser to cache it. Why is it so much slower than our other requests?

<img width="904" alt="Screen Shot 2021-06-10 at 1 20 20 PM" src="https://user-images.githubusercontent.com/217057/121591742-b3bf7300-c9ee-11eb-934f-9dde0712c1bb.png">

Ah, a cache miss from CloudFront! Turns out CloudFront doesn't enable caching options requests by default, but they can [easily be enabled](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/header-caching.html#header-caching-web-cors).

I tested this against my own cloudfront config.

**Before**
<img width="986" alt="Screen Shot 2021-06-10 at 12 54 51 PM" src="https://user-images.githubusercontent.com/217057/121590054-b15c1980-c9ec-11eb-8690-36ed90f67a88.png">

(note that at 298ms the preflight request is already faster in my baseline case, but I suspect that's only because I'm physically nearer to my own s3 origin than I am to the s3 origin used by flatgeobuf.septima.dk).

**After**
<img width="1224" alt="Screen Shot 2021-06-10 at 12 59 10 PM" src="https://user-images.githubusercontent.com/217057/121589980-9ab5c280-c9ec-11eb-92f4-08286663b9c0.png">
🚀 
