### PR TITLE
js: bbox fetches features in parallel batches

### DIFF
--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -4,7 +4,7 @@ import { terser } from 'rollup-plugin-terser'
 
 const plugins = [
   resolve({
-    resolveOnly: ['flatbuffers', 'slice-source']
+    resolveOnly: ['flatbuffers', 'slice-source', '@repeaterjs/repeater']
   }),
   babel({
     exclude: 'node_modules/**',

--- a/config/tsconfig.cjs.json
+++ b/config/tsconfig.cjs.json
@@ -9,7 +9,7 @@
         "declaration": true,
         "outDir": "../lib/cjs",
         "sourceMap": true,
-        "target": "ES5",
+        "target": "ES2019",
         "typeRoots": [ "./src/ts/types", "./node_modules/@types"],
         "allowSyntheticDefaultImports": true,
         "esModuleInterop": true

--- a/examples/leaflet/filtered.html
+++ b/examples/leaflet/filtered.html
@@ -1,9 +1,9 @@
 <html>
 <head>
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.6.0/dist/leaflet.css" />
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" />
     <link rel="stylesheet" href="/examples/site.css" />
     <script src="https://unpkg.com/underscore@1.13.1/underscore-min.js"></script>
-    <script src="https://unpkg.com/leaflet@1.6.0/dist/leaflet.js"></script>
+    <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
     <script src="https://unpkg.com/flatgeobuf@3.17.4/dist/flatgeobuf-geojson.min.js"></script>
     <script src="https://unpkg.com/json-formatter-js"></script>
 

--- a/examples/leaflet/index.html
+++ b/examples/leaflet/index.html
@@ -1,8 +1,8 @@
 <html>
 <head>
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.6.0/dist/leaflet.css" />
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" />
     <link rel="stylesheet" href="/examples/site.css" />
-    <script src="https://unpkg.com/leaflet@1.6.0/dist/leaflet.js"></script>
+    <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
     <script src="https://unpkg.com/flatgeobuf@3.17.4/dist/flatgeobuf-geojson.min.js"></script>
     <script src="https://unpkg.com/json-formatter-js"></script>
 

--- a/examples/leaflet/large.html
+++ b/examples/leaflet/large.html
@@ -32,7 +32,8 @@
             // basic OSM Leaflet map
             let map = L.map('map').setView([40.766, -73.98], 14);
             L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-                maxZoom: 19,
+                maxZoom: 18,
+                minZoom: 12,
                 attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
             }).addTo(map);
 

--- a/examples/leaflet/large.html
+++ b/examples/leaflet/large.html
@@ -1,9 +1,9 @@
 <html>
 <head>
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.6.0/dist/leaflet.css" />
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" />
     <link rel="stylesheet" href="/examples/site.css" />
     <script src="https://unpkg.com/underscore@1.13.1/underscore-min.js"></script>
-    <script src="https://unpkg.com/leaflet@1.6.0/dist/leaflet.js"></script>
+    <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
     <script src="https://unpkg.com/flatgeobuf@3.17.4/dist/flatgeobuf-geojson.min.js"></script>
     <script src="https://unpkg.com/json-formatter-js"></script>
 
@@ -47,8 +47,11 @@
 
             // For the example, we fix a visible Rect in the middle of the map
             function getBoundForRect() {
-                const widthMeters = 2000;
-                return map.getCenter().toBounds(widthMeters);
+                const bounds = map.getBounds();
+
+                const width = map.distance(bounds.getNorthWest(), bounds.getNorthEast());
+                const height = map.distance(bounds.getNorthWest(), bounds.getSouthWest());
+                return map.getCenter().toBounds(Math.min(width, height) * 0.8);
             }
 
             // convert the rect into the format flatgeobuf expects
@@ -62,6 +65,9 @@
                 };
             }
 
+            // show a leaflet rect corresponding to our bounding box
+            let rectangle = L.rectangle(getBoundForRect(), { interactive: false, color: "blue", fillOpacity: 0.0, opacity: 1.0 }).addTo(map);
+
             // track the previous results so we can remove them when adding new results
             let previousResults = L.layerGroup().addTo(map);
             async function updateResults() {
@@ -73,13 +79,25 @@
                 // Use flatgeobuf JavaScript API to iterate features as geojson.
                 // Because we specify a bounding box, flatgeobuf will only fetch the relevant subset of data,
                 // rather than the entire file.
-                let iter = flatgeobuf.deserialize('https://flatgeobuf.septima.dk/population_areas.fgb', fgBoundingBox(), handleHeaderMeta);
-                for await (let feature of iter) {
+                const iter = flatgeobuf.deserialize('https://flatgeobuf.septima.dk/population_areas.fgb', fgBoundingBox(), handleHeaderMeta);
+
+                const colorScale = ((d) => {
+                    return d > 750 ? '#800026' :
+                        d > 500 ? '#BD0026' :
+                        d > 250  ? '#E31A1C' :
+                        d > 100 ? '#FC4E2A' :
+                        d > 50   ? '#FD8D3C' :
+                        d > 25  ? '#FEB24C' :
+                        d > 10   ? '#FED976' :
+                        '#FFEDA0'
+                });
+
+                for await (const feature of iter) {
                     // Leaflet styling
                     const defaultStyle = { 
-                        color: 'blue', 
-                        weight: 2, 
-                        fillOpacity: 0.1,
+                        color: colorScale(feature.properties["population"]), 
+                        weight: 1, 
+                        fillOpacity: 0.4,
                     };
                     L.geoJSON(feature, {
                         style: defaultStyle,
@@ -87,11 +105,9 @@
                         'mouseover': function(e) {
                             const layer = e.target;
                             layer.setStyle({
-                                color: 'blue',
                                 weight: 4,
-                                fillOpacity: 0.7,
+                                fillOpacity: 0.8,
                             });
-                            layer.bringToFront();
                         },
                         'mouseout': function(e) {
                             const layer = e.target;
@@ -100,12 +116,10 @@
                    }).bindPopup(`${feature.properties["population"]} people live in this census block.</h1>`)
                    .addTo(nextResults);
                 }
+                rectangle.bringToFront();
             }
             // if the user is panning around alot, only update once per second max
             updateResults = _.throttle(updateResults, 1000);
-
-            // show a leaflet rect corresponding to our bounding box
-            let rectangle = L.rectangle(getBoundForRect(), { color: "yellow", fillOpacity: 0.7, opacity: 1.0 }).addTo(map);
 
             // show results based on the initial map
             updateResults();

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   },
   "homepage": "https://github.com/flatgeobuf/flatgeobuf#readme",
   "dependencies": {
+    "@repeaterjs/repeater": "^3.0.4",
     "flatbuffers": "2.0.3",
     "slice-source": "0.4.1",
     "stream-buffers": "3.0.2"

--- a/src/ts/Config.ts
+++ b/src/ts/Config.ts
@@ -1,0 +1,19 @@
+export default class Config {
+    static global = new Config();
+
+    private _extraRequestThreshold = 256 * 1024;
+
+    /**
+     * Fetch up to this many extra bytes if it will eliminate an extra request
+     */
+    public extraRequestThreshold(): number {
+        return this._extraRequestThreshold;
+    }
+
+    public setExtraRequestThreshold(bytes: number): void {
+        if (bytes < 0) {
+            throw new Error('extraRequestThreshold cannot be negative');
+        }
+        this._extraRequestThreshold = bytes;
+    }
+}

--- a/src/ts/HttpReader.ts
+++ b/src/ts/HttpReader.ts
@@ -213,10 +213,7 @@ export class HttpReader {
 
         const batchStart = firstFeatureOffset;
         const batchEnd = lastFeatureOffset + lastFeatureLength;
-
-        // I confess, I don't know why +1, but seeing an extra request (sometimes)
-        // when reading the final feature.
-        const batchSize = batchEnd - batchStart + 1;
+        const batchSize = batchEnd - batchStart;
 
         // A new feature client is needed for each batch to own the underlying buffer as features are yielded.
         const featureClient = this.buildFeatureClient();
@@ -293,7 +290,7 @@ class BufferedHttpRangeClient {
 
         const start_i = start - this.head;
         const end_i = start_i + length;
-        if (start_i >= 0 && end_i < this.buffer.byteLength) {
+        if (start_i >= 0 && end_i <= this.buffer.byteLength) {
             return this.buffer.slice(start_i, end_i);
         }
 

--- a/src/ts/generic/featurecollection.ts
+++ b/src/ts/generic/featurecollection.ts
@@ -124,8 +124,7 @@ export async function* deserializeFiltered(
     Logger.debug('opened reader');
     if (headerMetaFn) headerMetaFn(reader.header);
 
-    for await (const featureOffset of reader.selectBbox(rect)) {
-        const feature = await reader.readFeature(featureOffset[0]);
+    for await (const feature of reader.selectBbox(rect)) {
         yield fromFeature(feature, reader.header);
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -947,6 +947,11 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@repeaterjs/repeater@^3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@repeaterjs/repeater/-/repeater-3.0.4.tgz#a04d63f4d1bf5540a41b01a921c9a7fddc3bd1ca"
+  integrity sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA==
+
 "@rollup/plugin-babel@5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.3.0.tgz#9cb1c5146ddd6a4968ad96f209c50c62f92f9879"


### PR DESCRIPTION
When fetching features from a bbox query, long ago we used to very
naively fetch the precise range of each feature. This was efficient in
bytes, but resulted in lots of requests.

As of 860c411 we arbitrarily fetch some extra bytes on the chance that it'd obviate a
future request. In practice this performs fairly well - much better
than the naive approach. But you'd always have edge cases where you were
just a few bytes short of needed features, causing extra requests.

Rather than arbitrarily fetching an extra N bytes every time we fetch a
feature and hope it covers some soon-to-be-needed features, if we
instead knew the precise location and lengths of all the features we
need, we could explicitly combine the nearby ones into a single request.

Since the spatial index has the offsets of every feature*, we can do just
that - right-sizing our feature requests and surfacing a configuration
to let people tune the number of bytes they are willing to "spend" in
order to obviate a future request (see [src/ts/Config.ts]).

*the one exception is the very last feature. Since the "next" feature
serves as the bookend of "this* feature, we are left to just guess the
length of the last feature. In practice requesting a Range beyond the
end of the file results in fetching precisely what we need.


## Example

I've also spruced up the example a bit to highlight the feature properties as well as the geometry. Now that the client performs a bit better, I've also allowed the example to cover more map area. 

**after on the left / before on the right**
![image](https://user-images.githubusercontent.com/217057/122308919-30a48e00-cec2-11eb-9d52-7fa6ce4d083c.png)

