### PR TITLE
add test for writing fgb and loading it after with FgbWriter and FgbR…

### DIFF
--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -34,6 +34,7 @@ criterion = "0.3.3"
 tokio = { version = "1.0.2", default-features = false, features = ["macros"] }
 # One test needs SSL support; just use the default system bindings for that.
 reqwest = { version = "0.11.0", default-features = true }
+geo-types = "0.7.2"
 
 [[bench]]
 name = "read"

--- a/src/rust/tests/write.rs
+++ b/src/rust/tests/write.rs
@@ -1,5 +1,6 @@
 use crate::FgbWriter;
 use flatgeobuf::*;
+use geo_types::{line_string, LineString};
 use geozero::error::Result;
 use geozero::geojson::{GeoJson, GeoJsonReader};
 use geozero::{ColumnValue, GeozeroDatasource, PropertyProcessor};
@@ -137,4 +138,46 @@ fn geozero_to_fgb() -> Result<()> {
     let mut fout = BufWriter::new(tempfile()?);
     fgb.write(&mut fout)?;
     Ok(())
+}
+
+#[test]
+fn test_save_fgb_and_load() {
+    let tempf = tempfile().expect("test failed");
+
+    // Save
+    let linestrings: Vec<LineString<f64>> = vec![
+        geo_types::line_string![
+            (x: -21.95156, y: 64.1446),
+            (x: -21.951, y: 64.14479),
+            (x: -21.95044, y: 64.14527),
+            (x: -21.951445, y: 64.145508)
+        ],
+        geo_types::line_string![(x: 0.0, y: 0.0), (x: 1.0, y: 1.0),],
+    ];
+
+    let mut fgb = FgbWriter::create("test_write", GeometryType::LineString, |_fbb, header| {
+        header.features_count = linestrings.len() as u64;
+        header.index_node_size = 0;
+    })
+    .expect("test failed");
+    fgb.set_crs(4326, |_fbb, _crs| {});
+
+    for geom in linestrings.iter() {
+        let geom: geo_types::Geometry<f64> = geom.to_owned().into();
+        fgb.add_feature_geom(geom, |_feat| {}).expect("test failed");
+    }
+    let mut file = BufWriter::new(&tempf);
+    fgb.write(&mut file).expect("test failed");
+
+    // Load
+    let mut filein = BufReader::new(&tempf);
+    let mut fgb = FgbReader::open(&mut filein).expect("test failed");
+    fgb.select_all().expect("test failed");
+    let mut cnt = 0;
+    while let Some(feature) = fgb.next().expect("test failed") {
+        let _props = feature.properties().expect("test failed");
+        let _geometry = feature.geometry().unwrap();
+        cnt += 1
+    }
+    assert_eq!(cnt, 2);
 }


### PR DESCRIPTION
Adds a failing test that writes a FGB file using `FgbWriter` and attempts to read the file back in using `FgbReader`.

Writing is successful but reading is not returning an error `IoError(Error { kind: UnexpectedEof, message: "failed to fill whole buffer" })`

I have noted that files created using the `FgbWriter` have resulted in features counts double what they should be, it is possible I am not correctly setting the header `features_count` and the header is corrupt causing the file to load incorrectly.

The file does load with GDAL and shows the doubling of features count. These extra features are filtered out in the attribute editor of QGIS, so they seem to partially exist?

@pka I hope this PR helps. My `Result` handling could do with some work.