### PR TITLE
Run tsc compiler in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,9 @@ jobs:
           name: Run tests
           command: yarn test
       - run:
+          name: Run tsc compile
+          command: yarn build
+      - run:
           name: Run linter
           command: yarn fmt-check
 


### PR DESCRIPTION
Would it be reasonable to run this in CI as a guard against mistakes like I made in https://github.com/flatgeobuf/flatgeobuf/commit/3b4e22c33aac74cbb96ec6c6b299c20a692d8948 ?