### PR TITLE
Handle Json Column Type in typescript impl

### DIFF
--- a/src/ts/generic/feature.ts
+++ b/src/ts/generic/feature.ts
@@ -120,6 +120,16 @@ export function buildFeature(
                     offset += str.length;
                     break;
                 }
+                case ColumnType.Json: {
+                    const str = textEncoder.encode(JSON.stringify(value));
+                    prep(4);
+                    view.setUint32(offset, str.length, true);
+                    offset += 4;
+                    prep(str.length);
+                    bytes.set(str, offset);
+                    offset += str.length;
+                    break;
+                }
                 default:
                     throw new Error('Unknown type ' + column.type);
             }
@@ -216,6 +226,16 @@ export function parseProperties(
                 properties[name] = textDecoder.decode(
                     array.subarray(offset, offset + length)
                 );
+                offset += length;
+                break;
+            }
+            case ColumnType.Json: {
+                const length = view.getUint32(offset, true);
+                offset += 4;
+                const str = textDecoder.decode(
+                    array.subarray(offset, offset + length)
+                );
+                properties[name] = JSON.parse(str);
                 offset += length;
                 break;
             }

--- a/src/ts/geojson.spec.ts
+++ b/src/ts/geojson.spec.ts
@@ -343,7 +343,7 @@ describe('geojson module', () => {
 
         it('Json Value', () => {
             const expected = makeFeatureCollection('POINT(1 1)', {
-                test: {'hello': 'world'},
+                test: { hello: 'world' },
             });
             const actual = deserialize(serialize(expected));
             expect(actual).to.deep.equal(expected);

--- a/src/ts/geojson.spec.ts
+++ b/src/ts/geojson.spec.ts
@@ -340,6 +340,14 @@ describe('geojson module', () => {
             const actual = deserialize(serialize(expected));
             expect(actual).to.deep.equal(expected);
         });
+
+        it('Json Value', () => {
+            const expected = makeFeatureCollection('POINT(1 1)', {
+                test: {'hello': 'world'},
+            });
+            const actual = deserialize(serialize(expected));
+            expect(actual).to.deep.equal(expected);
+        });
     });
 
     describe('Prepared buffers tests', () => {

--- a/src/ts/geojson/featurecollection.ts
+++ b/src/ts/geojson/featurecollection.ts
@@ -82,7 +82,8 @@ function valueToType(value: boolean | number | string | unknown): ColumnType {
         else return ColumnType.Double;
     else if (typeof value === 'string') return ColumnType.String;
     else if (value === null) return ColumnType.String;
-    else return ColumnType.Json;
+    else if (typeof value === 'object') return ColumnType.Json;
+    else throw new Error(`Unknown type (value '${value}')`);
 }
 
 function introspectHeaderMeta(

--- a/src/ts/geojson/featurecollection.ts
+++ b/src/ts/geojson/featurecollection.ts
@@ -82,7 +82,7 @@ function valueToType(value: boolean | number | string | unknown): ColumnType {
         else return ColumnType.Double;
     else if (typeof value === 'string') return ColumnType.String;
     else if (value === null) return ColumnType.String;
-    else throw new Error(`Unknown type (value '${value}')`);
+    else return ColumnType.Json;
 }
 
 function introspectHeaderMeta(


### PR DESCRIPTION
Is this a correct read of the [JSON](https://github.com/flatgeobuf/flatgeobuf/blob/master/src/fbs/header.fbs#L39) column type?

I interpreted it to mean another UTF-8 string but with the assumption that it contains valid encoded JSON, and therefore could either be used to encode more complex JSON types (like objects or arrays), or potentially as an escape hatch for heterogeneous datasets.