### PR TITLE
Rework to use @types/geojson

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@rollup/plugin-babel": "5.3.0",
     "@rollup/plugin-node-resolve": "13.1.3",
     "@types/chai": "4.3.0",
+    "@types/geojson": "7946.0.8",
     "@types/mocha": "9.1.0",
     "@types/node": "17.0.15",
     "@types/stream-buffers": "3.0.4",

--- a/src/ts/generic/feature.ts
+++ b/src/ts/generic/feature.ts
@@ -144,7 +144,7 @@ export function buildFeature(
 
 export function parseProperties(
     feature: Feature,
-    columns: ColumnMeta[]
+    columns?: ColumnMeta[] | null
 ): Record<string, unknown> {
     const properties: Record<string, unknown> = {};
     if (!columns || columns.length === 0) return properties;

--- a/src/ts/geojson.spec.ts
+++ b/src/ts/geojson.spec.ts
@@ -21,8 +21,17 @@ import { arrayToStream, takeAsync } from './streams/utils.js';
 import { deserialize, serialize } from './geojson.js';
 import { IGeoJsonFeature } from './geojson/feature.js';
 import { Rect } from './packedrtree.js';
-import { IGeoJsonFeatureCollection } from './geojson/featurecollection.js';
 import HeaderMeta from './HeaderMeta.js';
+
+import {
+    FeatureCollection as GeoJsonFeatureCollection,
+    Point,
+    MultiPoint,
+    LineString,
+    MultiLineString,
+    Polygon,
+    MultiPolygon,
+} from 'geojson';
 
 function makeFeatureCollection(wkt: string, properties?: any) {
     return makeFeatureCollectionFromArray([wkt], properties);
@@ -33,13 +42,14 @@ function makeFeatureCollectionFromArray(wkts: string[], properties?: any) {
     const writer: any = new GeoJSONWriter();
     const geometries = wkts.map((wkt) => writer.write(reader.read(wkt)));
     const features = geometries.map(
-        (geometry) => ({ type: 'Feature', geometry } as IGeoJsonFeature)
+        (geometry) =>
+            ({ type: 'Feature', geometry, properties: {} } as IGeoJsonFeature)
     );
     if (properties) features.forEach((f) => (f.properties = properties));
     return {
         type: 'FeatureCollection',
         features,
-    };
+    } as GeoJsonFeatureCollection;
 }
 
 describe('geojson module', () => {
@@ -265,7 +275,7 @@ describe('geojson module', () => {
                     },
                 ],
             };
-            const actual = deserialize(serialize(expected));
+            const actual = deserialize(serialize(expected as any));
             expect(actual).to.deep.equal(expected);
         });
 
@@ -351,13 +361,21 @@ describe('geojson module', () => {
                 bytes,
                 undefined,
                 (header: HeaderMeta) => (headerMeta = header)
-            ) as IGeoJsonFeatureCollection;
+            ) as GeoJsonFeatureCollection;
             expect(headerMeta.crs.code).to.eq(4326);
             expect(geojson.features.length).to.eq(179);
-            for (const f of geojson.features)
-                expect(
-                    (f.geometry.coordinates[0] as number[]).length
-                ).to.be.greaterThan(0);
+            for (const f of geojson.features) {
+                const g = f.geometry as
+                    | Point
+                    | MultiPoint
+                    | LineString
+                    | MultiLineString
+                    | Polygon
+                    | MultiPolygon;
+                expect((g.coordinates[0] as number[]).length).to.be.greaterThan(
+                    0
+                );
+            }
         });
 
         it('Should parse countries fgb produced from GDAL stream filter', async () => {
@@ -414,27 +432,37 @@ describe('geojson module', () => {
         it('Should parse UScounties fgb produced from GDAL', () => {
             const buffer = readFileSync('./test/data/UScounties.fgb');
             const bytes = new Uint8Array(buffer);
-            const geojson = deserialize(bytes) as IGeoJsonFeatureCollection;
+            const geojson = deserialize(bytes) as GeoJsonFeatureCollection;
             expect(geojson.features.length).to.eq(3221);
-            for (const f of geojson.features)
-                expect(
-                    (f.geometry.coordinates[0] as number[]).length
-                ).to.be.greaterThan(0);
+            for (const f of geojson.features) {
+                const g = f.geometry as
+                    | Point
+                    | MultiPoint
+                    | LineString
+                    | MultiLineString
+                    | Polygon
+                    | MultiPolygon;
+                expect((g.coordinates[0] as number[]).length).to.be.greaterThan(
+                    0
+                );
+            }
         });
 
         it('Should parse heterogeneous fgb produced from Rust impl', () => {
             const buffer = readFileSync('./test/data/heterogeneous.fgb');
             const bytes = new Uint8Array(buffer);
-            const geojson = deserialize(bytes) as IGeoJsonFeatureCollection;
+            const geojson = deserialize(bytes) as GeoJsonFeatureCollection;
             const expected = {
                 type: 'FeatureCollection',
                 features: [
                     {
                         type: 'Feature',
+                        properties: {},
                         geometry: { type: 'Point', coordinates: [1.2, -2.1] },
                     },
                     {
                         type: 'Feature',
+                        properties: {},
                         geometry: {
                             type: 'LineString',
                             coordinates: [
@@ -445,6 +473,7 @@ describe('geojson module', () => {
                     },
                     {
                         type: 'Feature',
+                        properties: {},
                         geometry: {
                             type: 'MultiPolygon',
                             coordinates: [

--- a/src/ts/geojson.ts
+++ b/src/ts/geojson.ts
@@ -1,10 +1,11 @@
 import {
-    IGeoJsonFeatureCollection,
     deserialize as fcDeserialize,
     deserializeStream as fcDeserializeStream,
     deserializeFiltered as fcDeserializeFiltered,
     serialize as fcSerialize,
 } from './geojson/featurecollection.js';
+
+import { FeatureCollection as GeoJsonFeatureCollection } from 'geojson';
 
 import { Rect } from './packedrtree.js';
 import { IGeoJsonFeature } from './geojson/feature.js';
@@ -13,7 +14,7 @@ import { HeaderMetaFn } from './generic.js';
 /**
  * @param geojson GeoJSON object to serialize
  */
-export function serialize(geojson: IGeoJsonFeatureCollection): Uint8Array {
+export function serialize(geojson: GeoJsonFeatureCollection): Uint8Array {
     const bytes = fcSerialize(geojson);
     return bytes;
 }
@@ -28,7 +29,7 @@ export function deserialize(
     input: Uint8Array | ReadableStream | string,
     rect?: Rect,
     headerMetaFn?: HeaderMetaFn
-): IGeoJsonFeatureCollection | AsyncGenerator<IGeoJsonFeature> {
+): GeoJsonFeatureCollection | AsyncGenerator<IGeoJsonFeature> {
     if (input instanceof Uint8Array) return fcDeserialize(input, headerMetaFn);
     else if (input instanceof ReadableStream)
         return fcDeserializeStream(input, headerMetaFn);

--- a/src/ts/geojson/feature.ts
+++ b/src/ts/geojson/feature.ts
@@ -22,8 +22,5 @@ export function fromFeature(
         geometry,
         properties: parseProperties(feature, columns),
     };
-    // TODO: geojson types do not allow GeoJsonFeature without properties?
-    //if (columns && columns.length > 0)
-    //    geoJsonfeature.properties = parseProperties(feature, columns);
     return geoJsonfeature;
 }

--- a/src/ts/geojson/feature.ts
+++ b/src/ts/geojson/feature.ts
@@ -1,18 +1,12 @@
 import { Feature } from '../flat-geobuf/feature.js';
 import { Geometry } from '../flat-geobuf/geometry.js';
 import HeaderMeta from '../HeaderMeta.js';
-import { fromGeometry, IGeoJsonGeometry } from './geometry.js';
-import { parseProperties, IFeature } from '../generic/feature.js';
+import { fromGeometry } from './geometry.js';
+import { IFeature, parseProperties } from '../generic/feature.js';
 
-export interface IGeoJsonProperties {
-    [key: string]: boolean | number | string | any;
-}
+import { Feature as GeoJsonFeature } from 'geojson';
 
-export interface IGeoJsonFeature extends IFeature {
-    type: string;
-    geometry: IGeoJsonGeometry;
-    properties?: IGeoJsonProperties;
-}
+export interface IGeoJsonFeature extends IFeature, GeoJsonFeature {}
 
 export function fromFeature(
     feature: Feature,
@@ -23,11 +17,13 @@ export function fromFeature(
         feature.geometry() as Geometry,
         header.geometryType
     );
-    const geoJsonfeature: IGeoJsonFeature = {
+    const geoJsonfeature: GeoJsonFeature = {
         type: 'Feature',
         geometry,
+        properties: parseProperties(feature, columns),
     };
-    if (columns && columns.length > 0)
-        geoJsonfeature.properties = parseProperties(feature, columns);
+    // TODO: geojson types do not allow GeoJsonFeature without properties?
+    //if (columns && columns.length > 0)
+    //    geoJsonfeature.properties = parseProperties(feature, columns);
     return geoJsonfeature;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1085,6 +1085,11 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
+"@types/geojson@7946.0.8":
+  version "7946.0.8"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.8.tgz#30744afdb385e2945e22f3b033f897f76b1f12ca"
+  integrity sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA==
+
 "@types/json-schema@^7.0.9":
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"


### PR DESCRIPTION
Intended to resolve https://github.com/flatgeobuf/flatgeobuf/issues/178.

It actually made the implementation more compliant, as it seems the GeoJSON RFC and types make the feature properties member mandatory. I'm not sure I agree with it but standard is standard.

@drzax can you review this and even better, try it out to see if it solves your use case?