### PR TITLE
fix(ts): mem allocation for large feature props

### DIFF
--- a/src/ts/generic/feature.ts
+++ b/src/ts/generic/feature.ts
@@ -59,11 +59,11 @@ export function buildFeature(
 
     const prep = function (size: number) {
         if (offset + size < capacity) return;
-        capacity = capacity * 2;
+        capacity = Math.max(capacity + size, capacity * 2);
         const newBytes = new Uint8Array(capacity);
         newBytes.set(bytes);
         bytes = newBytes;
-        view = new DataView(bytes.buffer, offset);
+        view = new DataView(bytes.buffer);
     };
 
     if (columns) {
@@ -71,6 +71,7 @@ export function buildFeature(
             const column = columns[i];
             const value = properties[column.name];
             if (value === null) continue;
+            prep(2);
             view.setUint16(offset, i, true);
             offset += 2;
             switch (column.type) {

--- a/src/ts/geojson.spec.ts
+++ b/src/ts/geojson.spec.ts
@@ -288,6 +288,34 @@ describe('geojson module', () => {
             const actual = deserialize(serialize(expected));
             expect(actual).to.deep.equal(expected);
         });
+
+        it('Long feature properties', () => {
+            const expected = {
+                type: 'FeatureCollection',
+                features: [
+                    {
+                        type: 'Feature',
+                        properties: {
+                            veryLong1: Array(1024 * 10)
+                                .fill('X')
+                                .join(''),
+                            veryLong2: Array(1024 * 10)
+                                .fill('Y')
+                                .join(''),
+                            veryLong3: Array(1024 * 10)
+                                .fill('Z')
+                                .join(''),
+                        },
+                        geometry: {
+                            type: 'Point',
+                            coordinates: [-77.53466, 23.75975],
+                        },
+                    },
+                ],
+            };
+            const actual = deserialize(serialize(expected as any));
+            expect(actual).to.deep.equal(expected);
+        });
     });
 
     describe('Attribute roundtrips', () => {


### PR DESCRIPTION
This PR resolves a number of memory allocation issues in the TS implementation:

* offset being redefined, but setters assume offset is still 0 - as described here: https://github.com/flatgeobuf/flatgeobuf/issues/182
* correctly allocate memory when the `size` value passed to `prep(size)` exceeds `capacity * 2`
* call `prep()` when setting the index
* adds tests to validate against above issues