### PR TITLE
Bump Rust crate to 0.7.0

### DIFF
--- a/src/rust/CHANGELOG.md
+++ b/src/rust/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.7.0] - UNRELEASED
+## [0.7.0] - 2022-03-14
 
 - Add explicit reader/writer state to avoid wrong API use
   - Breaking: select_all/select_bbox now return the reader struct

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flatgeobuf"
-version = "0.6.2"
+version = "0.7.0"
 authors = ["Pirmin Kalberer <pka@sourcepole.ch>"]
 edition = "2018"
 description = "FlatGeobuf for Rust."

--- a/src/rust/fgbutil/src/main.rs
+++ b/src/rust/fgbutil/src/main.rs
@@ -37,10 +37,9 @@ enum Format {
 fn main() -> Result<()> {
     let args = Args::parse();
     let mut filein = BufReader::new(File::open(args.input)?);
-    let mut reader = FgbReader::open(&mut filein)?;
+    let mut reader = FgbReader::open(&mut filein)?.select_all()?;
     let mut output = std::io::stdout();
     let mut writer = GeoJsonWriter::new(&mut output);
-    reader.select_all()?;
     reader.process(&mut writer)?;
     Ok(())
 }


### PR DESCRIPTION
Would like to release the improvements since 0.6.2. There are no immediate plans for enhancements and `fgbutil` should work with this version.