### PR TITLE
Add MapLibre examples

### DIFF
--- a/examples/leaflet/filtered.html
+++ b/examples/leaflet/filtered.html
@@ -19,6 +19,9 @@
         <li>
             <a href="/examples/openlayers/filtered.html">OpenLayers Example</a>
         </li>
+        <li>
+            <a href="/examples/maplibre/">MapLibre Example</a>
+        </li>
     </ul>
     <ul class="secondary-navigation">
         <li><a href="/examples/leaflet/">Basic Example</a></li>

--- a/examples/leaflet/index.html
+++ b/examples/leaflet/index.html
@@ -17,6 +17,9 @@
         <li>
             <a href="/examples/openlayers/">OpenLayers Example</a>
         </li>
+        <li>
+            <a href="/examples/maplibre/">MapLibre Example</a>
+        </li>
     </ul>
     <ul class="secondary-navigation">
         <li class="active">Basic Example</li>

--- a/examples/leaflet/large.html
+++ b/examples/leaflet/large.html
@@ -19,6 +19,9 @@
         <li>
             <a href="/examples/openlayers/large.html">OpenLayers Example</a>
         </li>
+        <li>
+            <a href="/examples/maplibre/">MapLibre Example</a>
+        </li>
     </ul>
     <ul class="secondary-navigation">
         <li><a href="/examples/leaflet/">Basic Example</a></li>

--- a/examples/maplibre/filtered.html
+++ b/examples/maplibre/filtered.html
@@ -1,0 +1,215 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+    <link rel="stylesheet" href="/examples/site.css" />
+    <link href="https://unpkg.com/maplibre-gl@2.1.9/dist/maplibre-gl.css" rel="stylesheet" />
+    <script src="https://unpkg.com/maplibre-gl@2.1.9/dist/maplibre-gl.js"></script>
+    <script src="https://unpkg.com/underscore@1.13.1/underscore-min.js"></script>
+    <script src="https://unpkg.com/flatgeobuf@3.22.0/dist/flatgeobuf-geojson.min.js"></script>
+    <script src="https://unpkg.com/json-formatter-js"></script>
+
+    <style>
+        #map { height: 480px; }
+    </style>
+</head>
+<body>
+    <ul class="primary-navigation">
+        <li>
+            <a href="/examples/leaflet/">Leaflet Example</a>
+        </li>
+        <li>
+            <a href="/examples/openlayers/">OpenLayers Example</a>
+        </li>
+        <li class="active">
+            MapLibre Example
+        </li>
+    </ul>
+    <ul class="secondary-navigation">
+        <li><a href="/examples/maplibre/">Basic Example</a></li>
+        <li class="active">Filter By Rect</li>
+        <li><a href="/examples/maplibre/large.html">Filtering a Large Dataset</a></li>
+    </ul>
+
+    <div id="map"></div>
+    <script>
+        document.addEventListener("DOMContentLoaded", async () => {
+            // basic MapLibre map
+            const map = new maplibregl.Map({
+                container: "map",
+                style: "https://demotiles.maplibre.org/style.json",
+                center: [-104, 39],
+                zoom: 5,
+                maxZoom: 8,
+            });
+
+            // optionally show some meta-data about the FGB file
+            function handleHeaderMeta(headerMeta) {
+                const header = document.getElementById("header")
+                const formatter = new JSONFormatter(headerMeta, 10)
+                header.appendChild(formatter.render())
+            }
+
+            // convert the rect into the format flatgeobuf expects
+            function fgBoundingBox() {
+                const { lng, lat } = map.getCenter();
+                const size = 4;
+                return {minX: lng-size, minY: lat-size, maxX: lng+size, maxY: lat+size};
+            }
+
+            function getRect() {
+                const bbox = fgBoundingBox();
+                return {
+                    type: "FeatureCollection",
+                    features: [{
+                        type: "Feature",
+                        geometry: {
+                            type: "Polygon",
+                            coordinates: [[
+                                [bbox.minX, bbox.minY],
+                                [bbox.maxX, bbox.minY],
+                                [bbox.maxX, bbox.maxY],
+                                [bbox.minX, bbox.maxY],
+                                [bbox.minX, bbox.minY],
+                            ]]
+                        }
+                    }]
+                }
+            }
+
+            map.on("load", () => {
+                map.addSource("counties", {
+                    type: "geojson",
+                    data: {type: "FeatureCollection", features: []},
+                });
+                map.addLayer({
+                    id: "counties-fill",
+                    type: "fill",
+                    source: "counties",
+                    paint: {
+                        "fill-color": "#0000FF",
+                        "fill-opacity": [
+                            "case",
+                            ["boolean", ["feature-state", "hover"], false],
+                            1,
+                            0.5
+                        ],
+                    },
+                });
+                map.addLayer({
+                    id: "counties-line",
+                    type: "line",
+                    source: "counties",
+                    paint: {
+                      "line-color": "#0000FF",
+                      "line-opacity": 0.9,
+                      "line-width": 2,
+                    },
+                });
+
+                map.addSource("rectangle", {
+                    type: "geojson",
+                    data: {type: "FeatureCollection", features: []},
+                });
+                map.addLayer({
+                    id: "rectangle",
+                    type: "fill",
+                    source: "rectangle",
+                    paint: {
+                        "fill-color": "#FFFF00",
+                        "fill-opacity": 0.7,
+                    },
+                });
+
+                // from https://docs.mapbox.com/mapbox-gl-js/example/popup-on-click/
+                map.on("click", "counties-fill", (e) => {
+                    const props = e.features[0].properties;
+                    const html = `<h1>${props.NAME} ${props.LSAD}, ${props.STATE}</h1>`;
+                    new maplibregl.Popup()
+                        .setLngLat(e.lngLat)
+                        .setHTML(html)
+                        .addTo(map);
+                });
+
+                let hoveredStateId = null;
+                map.on("mousemove", "counties-fill", (e) => {
+                    if (e.features.length > 0) {
+                        if (hoveredStateId !== null) {
+                            map.setFeatureState(
+                                { source: "counties", id: hoveredStateId },
+                                { hover: false }
+                            );
+                        }
+                        hoveredStateId = e.features[0].id;
+                        map.setFeatureState(
+                            { source: "counties", id: hoveredStateId },
+                            { hover: true }
+                        );
+                    }
+                });
+                map.on("mouseenter", "counties-fill", () => {
+                    map.getCanvas().style.cursor = "pointer";
+                });
+
+                map.on("mouseleave", "counties-fill", () => {
+                    map.getCanvas().style.cursor = "";
+                    if (hoveredStateId !== null) {
+                        map.setFeatureState(
+                            { source: "counties", id: hoveredStateId },
+                            { hover: false }
+                        );
+                    }
+                    hoveredStateId = null;
+                });
+
+                // if the user is panning around alot, only update once per second max
+                updateResults = _.throttle(updateResults, 1000);
+
+                // show a rectangle corresponding to our bounding box
+                map.getSource("rectangle").setData(getRect());
+
+                // show results based on the initial map
+                updateResults();
+
+                // ...and update the results whenever the map moves
+                map.on("moveend", function(s){
+                map.getSource("rectangle").setData(getRect());
+                        updateResults();
+                });
+            });
+
+            async function updateResults() {
+                let i = 0;
+                const fc = {type: "FeatureCollection", features: []};
+                let iter = flatgeobuf.deserialize('/test/data/UScounties.fgb', fgBoundingBox(), handleHeaderMeta);
+                for await (let feature of iter) {
+                    fc.features.push({...feature, id: i});
+                    i += 1;
+                }
+                map.getSource("counties").setData(fc);
+            }
+        });
+    </script>
+    <p>
+        FlatGeobuf's spatial index allows you to fetch the features that
+        intersect a given bounding box, without downloading the entire file.
+        This can be helpful when you have a very large file but are only
+        interested in a small portion of it, and want to keep your page loads
+        small and fast.
+    </p>
+    <p>
+        For the purposes of the example we've highlighted our bounding box in
+        yellow. Pan the map to move the query's bounding box.
+    </p>
+    <p>
+        Open your developer console's network pane, and inspect the network
+        traffic. Compared to the <a href="/examples/maplibre/">example which loads the entire file</a>,
+        you'll see that this example makes more requests for the .fgb file, but
+        they are much smaller because we fetch only the relevant sections of
+        the file.
+    </p>
+    <div id="header">
+        <h3>Parsed header content</h3>
+    </div>
+</body>
+</html>

--- a/examples/maplibre/index.html
+++ b/examples/maplibre/index.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+    <link rel="stylesheet" href="/examples/site.css" />
+    <link href="https://unpkg.com/maplibre-gl@2.1.9/dist/maplibre-gl.css" rel="stylesheet" />
+    <script src="https://unpkg.com/maplibre-gl@2.1.9/dist/maplibre-gl.js"></script>
+    <script src="https://unpkg.com/flatgeobuf@3.22.0/dist/flatgeobuf-geojson.min.js"></script>
+    <script src="https://unpkg.com/json-formatter-js"></script>
+</head>
+<body>
+<style>
+</style>
+    <ul class="primary-navigation">
+        <li>
+            <a href="/examples/leaflet/">Leaflet Example</a>
+        </li>
+        <li>
+            <a href="/examples/openlayers/">OpenLayers Example</a>
+        </li>
+        <li class="active">
+            MapLibre Example
+        </li>
+    </ul>
+    <ul class="secondary-navigation">
+        <li class="active">Basic Example</li>
+        <li><a href="/examples/maplibre/filtered.html">Filter By Rect</a></li>
+        <li><a href="/examples/maplibre/large.html">Filtering a Large Dataset</a></li>
+    </ul>
+
+    <style>
+        #map { height: 480px; }
+    </style>
+    <div id="map"></div>
+    <script>
+        document.addEventListener("DOMContentLoaded", async () => {
+            // basic MapLibre map
+            const map = new maplibregl.Map({
+                container: "map",
+                style: "https://demotiles.maplibre.org/style.json",
+                center: [-98, 39],
+                zoom: 3,
+                maxZoom: 8,
+            });
+
+            // optionally show some meta-data about the FGB file
+            function handleHeaderMeta(headerMeta) {
+                const header = document.getElementById("header")
+                const formatter = new JSONFormatter(headerMeta, 10)
+                header.appendChild(formatter.render())
+            }
+
+            const response = await fetch("/test/data/UScounties.fgb");
+            map.on("load", async () => {
+                const fc = {type: "FeatureCollection", features: []};
+                let i = 0;
+                for await (const f of flatgeobuf.deserialize(response.body, undefined, handleHeaderMeta)) {
+                    fc.features.push({...f, id: i});
+                    i += 1;
+                }
+
+                map.addSource("counties", {
+                    type: "geojson",
+                    data: fc,
+                });
+                map.addLayer({
+                    id: "counties-fill",
+                    type: "fill",
+                    source: "counties",
+                    paint: {
+                        "fill-color": "#0000FF",
+                        "fill-opacity": [
+                            "case",
+                            ["boolean", ["feature-state", "hover"], false],
+                            1,
+                            0.5
+                        ],
+                    },
+                });
+                map.addLayer({
+                    id: "counties-line",
+                    type: "line",
+                    source: "counties",
+                    paint: {
+                      "line-color": "#0000FF",
+                      "line-opacity": 0.9,
+                      "line-width": 2,
+                    },
+                });
+
+                // from https://docs.mapbox.com/mapbox-gl-js/example/popup-on-click/
+                map.on("click", "counties-fill", (e) => {
+                    const props = e.features[0].properties;
+                    const html = `<h1>${props.NAME} ${props.LSAD}, ${props.STATE}</h1>`;
+                    new maplibregl.Popup()
+                        .setLngLat(e.lngLat)
+                        .setHTML(html)
+                        .addTo(map);
+                });
+
+                let hoveredStateId = null;
+                map.on("mousemove", "counties-fill", (e) => {
+                    if (e.features.length > 0) {
+                        if (hoveredStateId !== null) {
+                            map.setFeatureState(
+                                { source: "counties", id: hoveredStateId },
+                                { hover: false }
+                            );
+                        }
+                        hoveredStateId = e.features[0].id;
+                        map.setFeatureState(
+                            { source: "counties", id: hoveredStateId },
+                            { hover: true }
+                        );
+                    }
+                });
+                map.on("mouseenter", "counties-fill", () => {
+                    map.getCanvas().style.cursor = "pointer";
+                });
+                map.on("mouseleave", "counties-fill", () => {
+                    map.getCanvas().style.cursor = "";
+                    if (hoveredStateId !== null) {
+                        map.setFeatureState(
+                            { source: "counties", id: hoveredStateId },
+                            { hover: false }
+                        );
+                    }
+                    hoveredStateId = null;
+                });
+            });
+        });
+    </script>
+
+    <p>
+    This basic example shows how to render all the features in a FlatGeobuf
+    onto a <a href="https://maplibre.org/maplibre-gl-js-docs/">MapLibre</a> map.  It shows
+    per-feature properties when you click on each feature. This will work almost exactly
+    the same for Mapbox GL JS, just add an account key and load the Mapbox libraries instead.
+    </p>
+
+    <div id="header">
+        <h3>Parsed header content</h3>
+    </div>
+</body>
+</html>

--- a/examples/maplibre/simple.html
+++ b/examples/maplibre/simple.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+    <link href="https://unpkg.com/maplibre-gl@2.1.9/dist/maplibre-gl.css" rel="stylesheet" />
+    <script src="https://unpkg.com/maplibre-gl@2.1.9/dist/maplibre-gl.js"></script>
+    <script src="https://unpkg.com/flatgeobuf@3.22.0/dist/flatgeobuf-geojson.min.js"></script>
+    <style>
+        #map { height: 480px; }
+    </style>
+</head>
+<body>
+    <div id="map"></div>
+    <script type="module">
+        const map = new maplibregl.Map({
+            container: "map",
+            style: "https://demotiles.maplibre.org/style.json",
+            center: [-80.09, 41.505],
+            zoom: 3,
+            maxZoom: 8,
+        });
+
+        const response = await fetch("https://flatgeobuf.org/test/data/UScounties.fgb")
+        map.on("load", async () => {
+            const fc = {type: "FeatureCollection", features: []};
+            for await (const f of flatgeobuf.deserialize(response.body))
+                fc.features.push(f);
+
+            map.addSource("counties", {
+               type: "geojson",
+               data: fc,
+            });
+            map.addLayer({
+                id: "counties-fill",
+                type: "fill",
+                source: "counties",
+                paint: {
+                  "fill-color": "#0000FF",
+                  "fill-opacity": 0.2,
+                },
+            });
+            map.addLayer({
+                id: "counties-line",
+                type: "line",
+                source: "counties",
+                paint: {
+                  "line-color": "#0000FF",
+                  "line-opacity": 0.9,
+                  "line-width": 2,
+                },
+            });
+        });
+    </script>
+</body>
+</html>

--- a/examples/openlayers/filtered.html
+++ b/examples/openlayers/filtered.html
@@ -14,6 +14,9 @@
         <li class="active">
             OpenLayers Examples
         </li>
+        <li>
+            <a href="/examples/maplibre/">MapLibre Example</a>
+        </li>
     </ul>
     <ul class="secondary-navigation">
         <li><a href="/examples/openlayers/">Basic Example</a></li>

--- a/examples/openlayers/index.html
+++ b/examples/openlayers/index.html
@@ -13,6 +13,9 @@
         <li class="active">
             OpenLayers Examples
         </li>
+        <li>
+            <a href="/examples/maplibre/">MapLibre Example</a>
+        </li>
     </ul>
     <ul class="secondary-navigation">
         <li class="active">Basic Example</li>

--- a/examples/openlayers/large.html
+++ b/examples/openlayers/large.html
@@ -14,6 +14,9 @@
         <li class="active">
             OpenLayers Examples
         </li>
+        <li>
+            <a href="/examples/maplibre/">MapLibre Example</a>
+        </li>
     </ul>
     <ul class="secondary-navigation">
         <li><a href="/examples/openlayers/">Basic Example</a></li>


### PR DESCRIPTION
**NB** I haven't yet made an example for `large.html`, but will do so shortly.

Just wanted to get this up to check that it's worthwhile.

Used MapLibre (rather than Mapbox) purely so that no token would need to be tied to the examples.