### PR TITLE
add MapServer to list of supported applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ necessary.
 * [Geo Data Viewer (Visual Studio Code extension)](https://marketplace.visualstudio.com/items?itemName=RandomFractalsInc.geo-data-viewer) (2.3 and forward)
 * [GeoServer](https://geoserver.org) (2.17 and forward)
 * [GeoTools](https://geotools.org) (23.0 and forward)
+* [MapServer](https://mapserver.org/input/vector/flatgeobuf.html) (with GDAL >=3.1.0)
 * [PostGIS](https://postgis.net) (3.2.0 and forward)
 * [QGIS](https://qgis.org) (3.16 and forward)
 


### PR DESCRIPTION
- adds MapServer to list of supported applications
- points to new document & steps: https://mapserver.org/input/vector/flatgeobuf.html
  - that also includes how to setup MapServer to output FlatGeobuf for WFS services