### PR TITLE
remove redundant reversals from all clients

### DIFF
--- a/src/cpp/packedrtree.cpp
+++ b/src/cpp/packedrtree.cpp
@@ -220,12 +220,9 @@ std::vector<std::pair<uint64_t, uint64_t>> PackedRTree::generateLevelBounds(cons
     n = numNodes;
     for (auto size : levelNumNodes)
         levelOffsets.push_back(n -= size);
-    std::reverse(levelOffsets.begin(), levelOffsets.end());
-    std::reverse(levelNumNodes.begin(), levelNumNodes.end());
     std::vector<std::pair<uint64_t, uint64_t>> levelBounds;
     for (size_t i = 0; i < levelNumNodes.size(); i++)
         levelBounds.push_back(std::pair<uint64_t, uint64_t>(levelOffsets[i], levelOffsets[i] + levelNumNodes[i]));
-    std::reverse(levelBounds.begin(), levelBounds.end());
     return levelBounds;
 }
 

--- a/src/java/src/main/java/org/wololo/flatgeobuf/PackedRTree.java
+++ b/src/java/src/main/java/org/wololo/flatgeobuf/PackedRTree.java
@@ -54,12 +54,9 @@ public class PackedRTree {
             levelOffsets.add(n - size);
             n -= size;
         }
-        Collections.reverse(levelOffsets);
-        Collections.reverse(levelNumNodes);
         ArrayList<Integer> levelEnds = new ArrayList<Integer>();
         for (int i = 0; i < levelNumNodes.size(); i++)
             levelEnds.add(levelOffsets.get(i) + levelNumNodes.get(i));
-        Collections.reverse(levelEnds);
         return levelEnds;
     }
 

--- a/src/net/FlatGeobuf/Index/PackedRTree.cs
+++ b/src/net/FlatGeobuf/Index/PackedRTree.cs
@@ -54,12 +54,9 @@ namespace FlatGeobuf.Index
                 levelOffsets.Add(n - size);
                 n -= size;
             };
-            levelOffsets.Reverse();
-            levelNumNodes.Reverse();
             var levelBounds = new List<(ulong Start, ulong End)>();
             for (var i = 0; i < levelNumNodes.Count; i++)
                 levelBounds.Add((levelOffsets[i], levelOffsets[i] + levelNumNodes[i]));
-            levelBounds.Reverse();
             return levelBounds;
         }
 

--- a/src/rust/src/packed_r_tree.rs
+++ b/src/rust/src/packed_r_tree.rs
@@ -326,13 +326,10 @@ impl PackedRTree {
             level_offsets.push(n - size);
             n -= size;
         }
-        level_offsets.reverse();
-        level_num_nodes.reverse();
         let mut level_bounds = Vec::with_capacity(level_num_nodes.len());
         for i in 0..level_num_nodes.len() {
             level_bounds.push((level_offsets[i], level_offsets[i] + level_num_nodes[i]));
         }
-        level_bounds.reverse();
         level_bounds
     }
 

--- a/src/ts/packedrtree.ts
+++ b/src/ts/packedrtree.ts
@@ -55,12 +55,9 @@ export function generateLevelBounds(
         levelOffsets.push(n - size);
         n -= size;
     }
-    levelOffsets.reverse();
-    levelNumNodes.reverse();
     const levelBounds: Array<[number, number]> = [];
     for (let i = 0; i < levelNumNodes.length; i++)
         levelBounds.push([levelOffsets[i], levelOffsets[i] + levelNumNodes[i]]);
-    levelBounds.reverse();
     return levelBounds;
 }
 


### PR DESCRIPTION
This is a follow up to #232, but for all the other clients as well.

Previously we reversed a vec, which was made by (effectively) zipping together two reversed vecs, now we just skip all the reversals for the same end result.

Note that I haven't personally tested the `.cs` changes because I don't have a build environment set up for that, but I'm hoping CI will catch any issues there.