### PR TITLE
Constify hilbert sort

### DIFF
--- a/src/cpp/packedrtree.cpp
+++ b/src/cpp/packedrtree.cpp
@@ -26,7 +26,8 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
-// NOTE: The upstream of this file is in https://github.com/bjornharrtell/flatgeobuf/tree/master/src/cpp
+// NOTE: The upstream of this file is in
+// https://github.com/bjornharrtell/flatgeobuf/tree/master/src/cpp
 
 #ifdef GDAL_COMPILATION
 #include "cpl_port.h"
@@ -47,39 +48,45 @@ namespace FlatGeobuf
 
 const NodeItem &NodeItem::expand(const NodeItem &r)
 {
-    if (r.minX < minX) minX = r.minX;
-    if (r.minY < minY) minY = r.minY;
-    if (r.maxX > maxX) maxX = r.maxX;
-    if (r.maxY > maxY) maxY = r.maxY;
+    if (r.minX < minX)
+        minX = r.minX;
+    if (r.minY < minY)
+        minY = r.minY;
+    if (r.maxX > maxX)
+        maxX = r.maxX;
+    if (r.maxY > maxY)
+        maxY = r.maxY;
     return *this;
 }
 
 NodeItem NodeItem::create(uint64_t offset)
 {
-    return {
-        std::numeric_limits<double>::infinity(),
-        std::numeric_limits<double>::infinity(),
-        -1 * std::numeric_limits<double>::infinity(),
-        -1 * std::numeric_limits<double>::infinity(),
-        offset
-    };
+    return {std::numeric_limits<double>::infinity(),
+            std::numeric_limits<double>::infinity(),
+            -1 * std::numeric_limits<double>::infinity(),
+            -1 * std::numeric_limits<double>::infinity(), offset};
 }
 
 bool NodeItem::intersects(const NodeItem &r) const
 {
-    if (maxX < r.minX) return false;
-    if (maxY < r.minY) return false;
-    if (minX > r.maxX) return false;
-    if (minY > r.maxY) return false;
+    if (maxX < r.minX)
+        return false;
+    if (maxY < r.minY)
+        return false;
+    if (minX > r.maxX)
+        return false;
+    if (minY > r.maxY)
+        return false;
     return true;
 }
 
 std::vector<double> NodeItem::toVector()
 {
-    return std::vector<double> { minX, minY, maxX, maxY };
+    return std::vector<double>{minX, minY, maxX, maxY};
 }
 
-// Based on public domain code at https://github.com/rawrunprotected/hilbert_curves
+// Based on public domain code at
+// https://github.com/rawrunprotected/hilbert_curves
 uint32_t hilbert(uint32_t x, uint32_t y)
 {
     uint32_t a = x ^ y;
@@ -92,19 +99,28 @@ uint32_t hilbert(uint32_t x, uint32_t y)
     uint32_t C = ((c >> 1) ^ (b & (d >> 1))) ^ c;
     uint32_t D = ((a & (c >> 1)) ^ (d >> 1)) ^ d;
 
-    a = A; b = B; c = C; d = D;
+    a = A;
+    b = B;
+    c = C;
+    d = D;
     A = ((a & (a >> 2)) ^ (b & (b >> 2)));
     B = ((a & (b >> 2)) ^ (b & ((a ^ b) >> 2)));
     C ^= ((a & (c >> 2)) ^ (b & (d >> 2)));
     D ^= ((b & (c >> 2)) ^ ((a ^ b) & (d >> 2)));
 
-    a = A; b = B; c = C; d = D;
+    a = A;
+    b = B;
+    c = C;
+    d = D;
     A = ((a & (a >> 4)) ^ (b & (b >> 4)));
     B = ((a & (b >> 4)) ^ (b & ((a ^ b) >> 4)));
     C ^= ((a & (c >> 4)) ^ (b & (d >> 4)));
     D ^= ((b & (c >> 4)) ^ ((a ^ b) & (d >> 4)));
 
-    a = A; b = B; c = C; d = D;
+    a = A;
+    b = B;
+    c = C;
+    d = D;
     C ^= ((a & (c >> 8)) ^ (b & (d >> 8)));
     D ^= ((b & (c >> 8)) ^ ((a ^ b) & (d >> 8)));
 
@@ -129,15 +145,18 @@ uint32_t hilbert(uint32_t x, uint32_t y)
     return value;
 }
 
-uint32_t hilbert(const NodeItem &r, uint32_t hilbertMax, const double minX, const double minY, const double width, const double height)
+uint32_t hilbert(const NodeItem &r, uint32_t hilbertMax, const double minX,
+                 const double minY, const double width, const double height)
 {
     uint32_t x = 0;
     uint32_t y = 0;
     uint32_t v;
     if (width != 0.0)
-        x = static_cast<uint32_t>(floor(hilbertMax * ((r.minX + r.maxX) / 2 - minX) / width));
+        x = static_cast<uint32_t>(
+            floor(hilbertMax * ((r.minX + r.maxX) / 2 - minX) / width));
     if (height != 0.0)
-        y = static_cast<uint32_t>(floor(hilbertMax * ((r.minY + r.maxY) / 2 - minY) / height));
+        y = static_cast<uint32_t>(
+            floor(hilbertMax * ((r.minY + r.maxY) / 2 - minY) / height));
     v = hilbert(x, y);
     return v;
 }
@@ -149,11 +168,16 @@ void hilbertSort(std::vector<std::shared_ptr<Item>> &items)
     const double minY = extent.minY;
     const double width = extent.width();
     const double height = extent.height();
-    std::sort(items.begin(), items.end(), [minX, minY, width, height] (std::shared_ptr<Item> a, std::shared_ptr<Item> b) {
-        uint32_t ha = hilbert(a->nodeItem, HILBERT_MAX, minX, minY, width, height);
-        uint32_t hb = hilbert(b->nodeItem, HILBERT_MAX, minX, minY, width, height);
-        return ha > hb;
-    });
+    std::sort(items.begin(), items.end(),
+              [minX, minY, width, height](std::shared_ptr<Item> a,
+                                          std::shared_ptr<Item> b)
+              {
+                  uint32_t ha = hilbert(a->nodeItem, HILBERT_MAX, minX, minY,
+                                        width, height);
+                  uint32_t hb = hilbert(b->nodeItem, HILBERT_MAX, minX, minY,
+                                        width, height);
+                  return ha > hb;
+              });
 }
 
 void hilbertSort(std::vector<NodeItem> &items)
@@ -163,25 +187,29 @@ void hilbertSort(std::vector<NodeItem> &items)
     const double minY = extent.minY;
     const double width = extent.width();
     const double height = extent.height();
-    std::sort(items.begin(), items.end(), [minX, minY, width, height] (const NodeItem &a, const NodeItem &b) {
-        uint32_t ha = hilbert(a, HILBERT_MAX, minX, minY, width, height);
-        uint32_t hb = hilbert(b, HILBERT_MAX, minX, minY, width, height);
-        return ha > hb;
-    });
+    std::sort(items.begin(), items.end(),
+              [minX, minY, width, height](const NodeItem &a, const NodeItem &b)
+              {
+                  uint32_t ha =
+                      hilbert(a, HILBERT_MAX, minX, minY, width, height);
+                  uint32_t hb =
+                      hilbert(b, HILBERT_MAX, minX, minY, width, height);
+                  return ha > hb;
+              });
 }
 
 NodeItem calcExtent(const std::vector<std::shared_ptr<Item>> &items)
 {
-    return std::accumulate(items.begin(), items.end(), NodeItem::create(0), [] (NodeItem a, const std::shared_ptr<Item>& b) {
-        return a.expand(b->nodeItem);
-    });
+    return std::accumulate(items.begin(), items.end(), NodeItem::create(0),
+                           [](NodeItem a, const std::shared_ptr<Item> &b)
+                           { return a.expand(b->nodeItem); });
 }
 
 NodeItem calcExtent(const std::vector<NodeItem> &nodes)
 {
-    return std::accumulate(nodes.begin(), nodes.end(), NodeItem::create(0), [] (NodeItem a, const NodeItem &b) {
-        return a.expand(b);
-    });
+    return std::accumulate(nodes.begin(), nodes.end(), NodeItem::create(0),
+                           [](NodeItem a, const NodeItem &b)
+                           { return a.expand(b); });
 }
 
 void PackedRTree::init(const uint16_t nodeSize)
@@ -190,18 +218,23 @@ void PackedRTree::init(const uint16_t nodeSize)
         throw std::invalid_argument("Node size must be at least 2");
     if (_numItems == 0)
         throw std::invalid_argument("Cannot create empty tree");
-    _nodeSize = std::min(std::max(nodeSize, static_cast<uint16_t>(2)), static_cast<uint16_t>(65535));
+    _nodeSize = std::min(std::max(nodeSize, static_cast<uint16_t>(2)),
+                         static_cast<uint16_t>(65535));
     _levelBounds = generateLevelBounds(_numItems, _nodeSize);
     _numNodes = _levelBounds.front().second;
     _nodeItems = new NodeItem[static_cast<size_t>(_numNodes)];
 }
 
-std::vector<std::pair<uint64_t, uint64_t>> PackedRTree::generateLevelBounds(const uint64_t numItems, const uint16_t nodeSize) {
+std::vector<std::pair<uint64_t, uint64_t>>
+PackedRTree::generateLevelBounds(const uint64_t numItems,
+                                 const uint16_t nodeSize)
+{
     if (nodeSize < 2)
         throw std::invalid_argument("Node size must be at least 2");
     if (numItems == 0)
         throw std::invalid_argument("Number of items must be greater than 0");
-    if (numItems > std::numeric_limits<uint64_t>::max() - ((numItems / nodeSize) * 2))
+    if (numItems >
+        std::numeric_limits<uint64_t>::max() - ((numItems / nodeSize) * 2))
         throw std::overflow_error("Number of items too large");
 
     // number of nodes per level in bottom-up order
@@ -209,7 +242,8 @@ std::vector<std::pair<uint64_t, uint64_t>> PackedRTree::generateLevelBounds(cons
     uint64_t n = numItems;
     uint64_t numNodes = n;
     levelNumNodes.push_back(n);
-    do {
+    do
+    {
         n = (n + nodeSize - 1) / nodeSize;
         numNodes += n;
         levelNumNodes.push_back(n);
@@ -222,17 +256,20 @@ std::vector<std::pair<uint64_t, uint64_t>> PackedRTree::generateLevelBounds(cons
         levelOffsets.push_back(n -= size);
     std::vector<std::pair<uint64_t, uint64_t>> levelBounds;
     for (size_t i = 0; i < levelNumNodes.size(); i++)
-        levelBounds.push_back(std::pair<uint64_t, uint64_t>(levelOffsets[i], levelOffsets[i] + levelNumNodes[i]));
+        levelBounds.push_back(std::pair<uint64_t, uint64_t>(
+            levelOffsets[i], levelOffsets[i] + levelNumNodes[i]));
     return levelBounds;
 }
 
 void PackedRTree::generateNodes()
 {
-    for (uint32_t i = 0; i < _levelBounds.size() - 1; i++) {
+    for (uint32_t i = 0; i < _levelBounds.size() - 1; i++)
+    {
         auto pos = _levelBounds[i].first;
         auto end = _levelBounds[i].second;
         auto newpos = _levelBounds[i + 1].first;
-        while (pos < end) {
+        while (pos < end)
+        {
             NodeItem node = NodeItem::create(pos);
             for (uint32_t j = 0; j < _nodeSize && pos < end; j++)
                 node.expand(_nodeItems[pos++]);
@@ -245,16 +282,17 @@ void PackedRTree::fromData(const void *data)
 {
     auto buf = reinterpret_cast<const uint8_t *>(data);
     const NodeItem *pn = reinterpret_cast<const NodeItem *>(buf);
-    for (uint64_t i = 0; i < _numNodes; i++) {
+    for (uint64_t i = 0; i < _numNodes; i++)
+    {
         NodeItem n = *pn++;
         _nodeItems[i] = n;
         _extent.expand(n);
     }
 }
 
-PackedRTree::PackedRTree(const std::vector<std::shared_ptr<Item>> &items, const NodeItem &extent, const uint16_t nodeSize) :
-    _extent(extent),
-    _numItems(items.size())
+PackedRTree::PackedRTree(const std::vector<std::shared_ptr<Item>> &items,
+                         const NodeItem &extent, const uint16_t nodeSize)
+    : _extent(extent), _numItems(items.size())
 {
     init(nodeSize);
     for (size_t i = 0; i < _numItems; i++)
@@ -262,9 +300,9 @@ PackedRTree::PackedRTree(const std::vector<std::shared_ptr<Item>> &items, const 
     generateNodes();
 }
 
-PackedRTree::PackedRTree(const std::vector<NodeItem> &nodes, const NodeItem &extent, const uint16_t nodeSize) :
-    _extent(extent),
-    _numItems(nodes.size())
+PackedRTree::PackedRTree(const std::vector<NodeItem> &nodes,
+                         const NodeItem &extent, const uint16_t nodeSize)
+    : _extent(extent), _numItems(nodes.size())
 {
     init(nodeSize);
     for (size_t i = 0; i < _numItems; i++)
@@ -272,47 +310,54 @@ PackedRTree::PackedRTree(const std::vector<NodeItem> &nodes, const NodeItem &ext
     generateNodes();
 }
 
-PackedRTree::PackedRTree(const void *data, const uint64_t numItems, const uint16_t nodeSize) :
-    _extent(NodeItem::create(0)),
-    _numItems(numItems)
+PackedRTree::PackedRTree(const void *data, const uint64_t numItems,
+                         const uint16_t nodeSize)
+    : _extent(NodeItem::create(0)), _numItems(numItems)
 {
     init(nodeSize);
     fromData(data);
 }
 
-PackedRTree::PackedRTree(std::function<void(NodeItem *)> fillNodeItems, const uint64_t numItems, const NodeItem &extent, const uint16_t nodeSize) :
-    _extent(extent),
-    _numItems(numItems)
+PackedRTree::PackedRTree(std::function<void(NodeItem *)> fillNodeItems,
+                         const uint64_t numItems, const NodeItem &extent,
+                         const uint16_t nodeSize)
+    : _extent(extent), _numItems(numItems)
 {
     init(nodeSize);
     fillNodeItems(_nodeItems + _numNodes - _numItems);
     generateNodes();
 }
 
-std::vector<SearchResultItem> PackedRTree::search(double minX, double minY, double maxX, double maxY) const
+std::vector<SearchResultItem>
+PackedRTree::search(double minX, double minY, double maxX, double maxY) const
 {
     uint64_t leafNodesOffset = _levelBounds.front().first;
-    NodeItem n { minX, minY, maxX, maxY, 0 };
+    NodeItem n{minX, minY, maxX, maxY, 0};
     std::vector<SearchResultItem> results;
     std::unordered_map<uint64_t, uint64_t> queue;
     queue.insert(std::pair<uint64_t, uint64_t>(0, _levelBounds.size() - 1));
-    while(queue.size() != 0) {
+    while (queue.size() != 0)
+    {
         auto next = queue.begin();
         uint64_t nodeIndex = next->first;
         uint64_t level = next->second;
         queue.erase(next);
         bool isLeafNode = nodeIndex >= _numNodes - _numItems;
         // find the end index of the node
-        uint64_t end = std::min(static_cast<uint64_t>(nodeIndex + _nodeSize), _levelBounds[static_cast<size_t>(level)].second);
+        uint64_t end =
+            std::min(static_cast<uint64_t>(nodeIndex + _nodeSize),
+                     _levelBounds[static_cast<size_t>(level)].second);
         // search through child nodes
-        for (uint64_t pos = nodeIndex; pos < end; pos++) {
+        for (uint64_t pos = nodeIndex; pos < end; pos++)
+        {
             auto nodeItem = _nodeItems[static_cast<size_t>(pos)];
             if (!n.intersects(nodeItem))
                 continue;
             if (isLeafNode)
-                results.push_back({ nodeItem.offset, pos - leafNodesOffset });
+                results.push_back({nodeItem.offset, pos - leafNodesOffset});
             else
-                queue.insert(std::pair<uint64_t, uint64_t>(nodeItem.offset, level - 1));
+                queue.insert(
+                    std::pair<uint64_t, uint64_t>(nodeItem.offset, level - 1));
         }
     }
     return results;
@@ -331,18 +376,21 @@ std::vector<SearchResultItem> PackedRTree::streamSearch(
     std::map<uint64_t, uint64_t> queue;
     std::vector<SearchResultItem> results;
     queue.insert(std::pair<uint64_t, uint64_t>(0, levelBounds.size() - 1));
-    while(queue.size() != 0) {
+    while (queue.size() != 0)
+    {
         auto next = queue.begin();
         uint64_t nodeIndex = next->first;
         uint64_t level = next->second;
         queue.erase(next);
         bool isLeafNode = nodeIndex >= numNodes - numItems;
         // find the end index of the node
-        uint64_t end = std::min(static_cast<uint64_t>(nodeIndex + nodeSize), levelBounds[static_cast<size_t>(level)].second);
+        uint64_t end = std::min(static_cast<uint64_t>(nodeIndex + nodeSize),
+                                levelBounds[static_cast<size_t>(level)].second);
         uint64_t length = end - nodeIndex;
-        readNode(nodesBuf, static_cast<size_t>(nodeIndex * sizeof(NodeItem)), static_cast<size_t>(length * sizeof(NodeItem)));
+        readNode(nodesBuf, static_cast<size_t>(nodeIndex * sizeof(NodeItem)),
+                 static_cast<size_t>(length * sizeof(NodeItem)));
 #if !CPL_IS_LSB
-        for( size_t i = 0; i < static_cast<size_t>(length); i++ )
+        for (size_t i = 0; i < static_cast<size_t>(length); i++)
         {
             CPL_LSBPTR64(&nodeItems[i].minX);
             CPL_LSBPTR64(&nodeItems[i].minY);
@@ -352,21 +400,26 @@ std::vector<SearchResultItem> PackedRTree::streamSearch(
         }
 #endif
         // search through child nodes
-        for (uint64_t pos = nodeIndex; pos < end; pos++) {
+        for (uint64_t pos = nodeIndex; pos < end; pos++)
+        {
             uint64_t nodePos = pos - nodeIndex;
             auto nodeItem = nodeItems[static_cast<size_t>(nodePos)];
             if (!item.intersects(nodeItem))
                 continue;
             if (isLeafNode)
-                results.push_back({ nodeItem.offset, pos - leafNodesOffset });
+                results.push_back({nodeItem.offset, pos - leafNodesOffset});
             else
-                queue.insert(std::pair<uint64_t, uint64_t>(nodeItem.offset, level - 1));
+                queue.insert(
+                    std::pair<uint64_t, uint64_t>(nodeItem.offset, level - 1));
         }
     }
     return results;
 }
 
-uint64_t PackedRTree::size() const { return _numNodes * sizeof(NodeItem); }
+uint64_t PackedRTree::size() const
+{
+    return _numNodes * sizeof(NodeItem);
+}
 
 uint64_t PackedRTree::size(const uint64_t numItems, const uint16_t nodeSize)
 {
@@ -374,22 +427,27 @@ uint64_t PackedRTree::size(const uint64_t numItems, const uint16_t nodeSize)
         throw std::invalid_argument("Node size must be at least 2");
     if (numItems == 0)
         throw std::invalid_argument("Number of items must be greater than 0");
-    const uint16_t nodeSizeMin = std::min(std::max(nodeSize, static_cast<uint16_t>(2)), static_cast<uint16_t>(65535));
+    const uint16_t nodeSizeMin =
+        std::min(std::max(nodeSize, static_cast<uint16_t>(2)),
+                 static_cast<uint16_t>(65535));
     // limit so that resulting size in bytes can be represented by uint64_t
     if (numItems > static_cast<uint64_t>(1) << 56)
         throw std::overflow_error("Number of items must be less than 2^56");
     uint64_t n = numItems;
     uint64_t numNodes = n;
-    do {
+    do
+    {
         n = (n + nodeSizeMin - 1) / nodeSizeMin;
         numNodes += n;
     } while (n != 1);
     return numNodes * sizeof(NodeItem);
 }
 
-void PackedRTree::streamWrite(const std::function<void(uint8_t *, size_t)> &writeData) {
+void PackedRTree::streamWrite(
+    const std::function<void(uint8_t *, size_t)> &writeData)
+{
 #if !CPL_IS_LSB
-    for( size_t i = 0; i < static_cast<size_t>(_numNodes); i++ )
+    for (size_t i = 0; i < static_cast<size_t>(_numNodes); i++)
     {
         CPL_LSBPTR64(&_nodeItems[i].minX);
         CPL_LSBPTR64(&_nodeItems[i].minY);
@@ -398,9 +456,10 @@ void PackedRTree::streamWrite(const std::function<void(uint8_t *, size_t)> &writ
         CPL_LSBPTR64(&_nodeItems[i].offset);
     }
 #endif
-    writeData(reinterpret_cast<uint8_t *>(_nodeItems), static_cast<size_t>(_numNodes * sizeof(NodeItem)));
+    writeData(reinterpret_cast<uint8_t *>(_nodeItems),
+              static_cast<size_t>(_numNodes * sizeof(NodeItem)));
 #if !CPL_IS_LSB
-    for( size_t i = 0; i < static_cast<size_t>(_numNodes); i++ )
+    for (size_t i = 0; i < static_cast<size_t>(_numNodes); i++)
     {
         CPL_LSBPTR64(&_nodeItems[i].minX);
         CPL_LSBPTR64(&_nodeItems[i].minY);
@@ -411,6 +470,9 @@ void PackedRTree::streamWrite(const std::function<void(uint8_t *, size_t)> &writ
 #endif
 }
 
-NodeItem PackedRTree::getExtent() const { return _extent; }
-
+NodeItem PackedRTree::getExtent() const
+{
+    return _extent;
 }
+
+}  // namespace FlatGeobuf

--- a/src/cpp/packedrtree.h
+++ b/src/cpp/packedrtree.h
@@ -104,7 +104,7 @@ template <class ITEM_TYPE> void hilbertSort(std::deque<ITEM_TYPE> &items)
     const double height = extent.height();
     std::sort(
         items.begin(), items.end(),
-        [minX, minY, width, height](ITEM_TYPE &a, ITEM_TYPE &b)
+        [minX, minY, width, height](const ITEM_TYPE &a, const ITEM_TYPE &b)
         {
             uint32_t ha =
                 hilbert(a.nodeItem, HILBERT_MAX, minX, minY, width, height);

--- a/src/cpp/packedrtree.h
+++ b/src/cpp/packedrtree.h
@@ -26,7 +26,8 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
-// NOTE: The upstream of this file is in https://github.com/bjornharrtell/flatgeobuf/tree/master/src/cpp
+// NOTE: The upstream of this file is in
+// https://github.com/bjornharrtell/flatgeobuf/tree/master/src/cpp
 
 #ifndef FLATGEOBUF_PACKEDRTREE_H_
 #define FLATGEOBUF_PACKEDRTREE_H_
@@ -37,17 +38,26 @@
 
 #include "flatbuffers/flatbuffers.h"
 
-namespace FlatGeobuf {
+namespace FlatGeobuf
+{
 
-struct NodeItem {
+struct NodeItem
+{
     double minX;
     double minY;
     double maxX;
     double maxY;
     uint64_t offset;
-    double width() const { return maxX - minX; }
-    double height() const { return maxY - minY; }
-    static NodeItem sum(NodeItem a, const NodeItem &b) {
+    double width() const
+    {
+        return maxX - minX;
+    }
+    double height() const
+    {
+        return maxY - minY;
+    }
+    static NodeItem sum(NodeItem a, const NodeItem &b)
+    {
         a.expand(b);
         return a;
     }
@@ -57,42 +67,51 @@ struct NodeItem {
     std::vector<double> toVector();
 };
 
-struct Item {
+struct Item
+{
     NodeItem nodeItem;
 };
 
-struct SearchResultItem {
+struct SearchResultItem
+{
     uint64_t offset;
     uint64_t index;
 };
 
-std::ostream& operator << (std::ostream& os, NodeItem const& value);
+std::ostream &operator<<(std::ostream &os, NodeItem const &value);
 
 uint32_t hilbert(uint32_t x, uint32_t y);
-uint32_t hilbert(const NodeItem &n, uint32_t hilbertMax, const double minX, const double minY, const double width, const double height);
+uint32_t hilbert(const NodeItem &n, uint32_t hilbertMax, const double minX,
+                 const double minY, const double width, const double height);
 void hilbertSort(std::vector<std::shared_ptr<Item>> &items);
 
 constexpr uint32_t HILBERT_MAX = (1 << 16) - 1;
 
-template<class ITEM_TYPE> NodeItem calcExtent(const std::deque<ITEM_TYPE> &items)
+template <class ITEM_TYPE>
+NodeItem calcExtent(const std::deque<ITEM_TYPE> &items)
 {
-    return std::accumulate(items.begin(), items.end(), NodeItem::create(0), [] (NodeItem a, const ITEM_TYPE& b) {
-        return a.expand(b.nodeItem);
-    });
+    return std::accumulate(items.begin(), items.end(), NodeItem::create(0),
+                           [](NodeItem a, const ITEM_TYPE &b)
+                           { return a.expand(b.nodeItem); });
 }
 
-template<class ITEM_TYPE> void hilbertSort(std::deque<ITEM_TYPE> &items)
+template <class ITEM_TYPE> void hilbertSort(std::deque<ITEM_TYPE> &items)
 {
     NodeItem extent = calcExtent(items);
     const double minX = extent.minX;
     const double minY = extent.minY;
     const double width = extent.width();
     const double height = extent.height();
-    std::sort(items.begin(), items.end(), [minX, minY, width, height] (ITEM_TYPE& a, ITEM_TYPE& b) {
-        uint32_t ha = hilbert(a.nodeItem, HILBERT_MAX, minX, minY, width, height);
-        uint32_t hb = hilbert(b.nodeItem, HILBERT_MAX, minX, minY, width, height);
-        return ha > hb;
-    });
+    std::sort(
+        items.begin(), items.end(),
+        [minX, minY, width, height](ITEM_TYPE &a, ITEM_TYPE &b)
+        {
+            uint32_t ha =
+                hilbert(a.nodeItem, HILBERT_MAX, minX, minY, width, height);
+            uint32_t hb =
+                hilbert(b.nodeItem, HILBERT_MAX, minX, minY, width, height);
+            return ha > hb;
+        });
 }
 
 void hilbertSort(std::vector<NodeItem> &items);
@@ -103,7 +122,8 @@ NodeItem calcExtent(const std::vector<NodeItem> &rects);
  * Packed R-Tree
  * Based on https://github.com/mourner/flatbush
  */
-class PackedRTree {
+class PackedRTree
+{
     NodeItem _extent;
     NodeItem *_nodeItems = nullptr;
     uint64_t _numItems;
@@ -113,26 +133,35 @@ class PackedRTree {
     void init(const uint16_t nodeSize);
     void generateNodes();
     void fromData(const void *data);
-public:
-    ~PackedRTree() {
+
+  public:
+    ~PackedRTree()
+    {
         if (_nodeItems != nullptr)
             delete[] _nodeItems;
     }
-    PackedRTree(const std::vector<std::shared_ptr<Item>> &items, const NodeItem &extent, const uint16_t nodeSize = 16);
-    PackedRTree(const std::vector<NodeItem> &nodes, const NodeItem &extent, const uint16_t nodeSize = 16);
-    PackedRTree(const void *data, const uint64_t numItems, const uint16_t nodeSize = 16);
-    PackedRTree(std::function<void(NodeItem *)> fillNodeItems, const uint64_t numItems, const NodeItem &extent, const uint16_t nodeSize = 16);
-    std::vector<SearchResultItem> search(double minX, double minY, double maxX, double maxY) const;
+    PackedRTree(const std::vector<std::shared_ptr<Item>> &items,
+                const NodeItem &extent, const uint16_t nodeSize = 16);
+    PackedRTree(const std::vector<NodeItem> &nodes, const NodeItem &extent,
+                const uint16_t nodeSize = 16);
+    PackedRTree(const void *data, const uint64_t numItems,
+                const uint16_t nodeSize = 16);
+    PackedRTree(std::function<void(NodeItem *)> fillNodeItems,
+                const uint64_t numItems, const NodeItem &extent,
+                const uint16_t nodeSize = 16);
+    std::vector<SearchResultItem> search(double minX, double minY, double maxX,
+                                         double maxY) const;
     static std::vector<SearchResultItem> streamSearch(
         const uint64_t numItems, const uint16_t nodeSize, const NodeItem &item,
         const std::function<void(uint8_t *, size_t, size_t)> &readNode);
-    static std::vector<std::pair<uint64_t, uint64_t>> generateLevelBounds(const uint64_t numItems, const uint16_t nodeSize);
+    static std::vector<std::pair<uint64_t, uint64_t>>
+    generateLevelBounds(const uint64_t numItems, const uint16_t nodeSize);
     uint64_t size() const;
     static uint64_t size(const uint64_t numItems, const uint16_t nodeSize = 16);
     NodeItem getExtent() const;
     void streamWrite(const std::function<void(uint8_t *, size_t)> &writeData);
 };
 
-}
+}  // namespace FlatGeobuf
 
 #endif


### PR DESCRIPTION
- packedrtree.h/.cpp: reformat from GDAL's copy
- hilbertSort(): add missing const qualifier to please ancient gcc 4.8.5 from CentOS 7.9 (from https://github.com/OSGeo/gdal/pull/6992)
