### PR TITLE
rust: fix inconsistent result ordering

### DIFF
--- a/src/rust/src/packed_r_tree.rs
+++ b/src/rust/src/packed_r_tree.rs
@@ -775,9 +775,11 @@ fn tree_19items_roundtrip_stream_search() -> Result<()> {
     let tree = PackedRTree::build(&nodes, &extent, PackedRTree::DEFAULT_NODE_SIZE)?;
     let list = tree.search(102.0, 102.0, 103.0, 103.0)?;
     assert_eq!(list.len(), 4);
-    for i in 0..list.len() {
-        assert!(nodes[list[i].index].intersects(&NodeItem::new(102.0, 102.0, 103.0, 103.0)));
-    }
+
+    let indexes: Vec<usize> = list.iter().map(|item| item.index).collect();
+    let expected: Vec<usize> = vec![13, 14, 15, 16];
+    assert_eq!(indexes, expected);
+
     let mut tree_data: Vec<u8> = Vec::new();
     let res = tree.stream_write(&mut tree_data);
     assert!(res.is_ok());
@@ -791,9 +793,10 @@ fn tree_19items_roundtrip_stream_search() -> Result<()> {
     )?;
     let list = tree2.search(102.0, 102.0, 103.0, 103.0)?;
     assert_eq!(list.len(), 4);
-    for i in 0..list.len() {
-        assert!(nodes[list[i].index].intersects(&NodeItem::new(102.0, 102.0, 103.0, 103.0)));
-    }
+
+    let indexes: Vec<usize> = list.iter().map(|item| item.index).collect();
+    let expected: Vec<usize> = vec![13, 14, 15, 16];
+    assert_eq!(indexes, expected);
 
     let mut reader = std::io::Cursor::new(&tree_data);
     let list = PackedRTree::stream_search(
@@ -806,9 +809,11 @@ fn tree_19items_roundtrip_stream_search() -> Result<()> {
         103.0,
     )?;
     assert_eq!(list.len(), 4);
-    for i in 0..list.len() {
-        assert!(nodes[list[i].index].intersects(&NodeItem::new(102.0, 102.0, 103.0, 103.0)));
-    }
+
+    let indexes: Vec<usize> = list.iter().map(|item| item.index).collect();
+    let expected: Vec<usize> = vec![13, 14, 15, 16];
+    assert_eq!(indexes, expected);
+
     Ok(())
 }
 


### PR DESCRIPTION
In the `search` method, we're using a HashMap as a "queue" but HashMaps don't
maintain ordering. So we sometimes see results returned in different order.

Since we're traversing the tree breadth first, we don't need a sorting data
structure - we can just add things to the back of a proper queue and pull from
the front. That is enough to ensure we're always getting the lowest index.

In the `streamSearch` method we were using a BinaryHeap which sorts based on index.
This behaved correctly, in that results were always in the correct order, but
it is unnecessarily slow/complicated.

In the HTTPSearch we were already using a VecDeque, so no changes there.

Related discussion occurred in #277, #274