### PR TITLE
Rust: Bump deps & 2021 edition, reexports, clippy

### DIFF
--- a/src/rust/CHANGELOG.md
+++ b/src/rust/CHANGELOG.md
@@ -93,7 +93,7 @@
 ## [0.3.1] - 2020-04-05
 
 - Rust FlatGeobuf reading via HTTP (#49)
-- Add Rust docs URL and update READMEs (#48)
+- Add Rust docs URL and update README files (#48)
 
 ## [0.3.0] - 2020-03-20
 

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -2,8 +2,8 @@
 name = "flatgeobuf"
 version = "3.26.1"
 authors = ["Pirmin Kalberer <pka@sourcepole.ch>"]
-edition = "2018"
-description = "FlatGeobuf for Rust."
+edition = "2021"
+description = "FlatGeobuf for Rust"
 homepage = "https://flatgeobuf.org/"
 repository = "https://github.com/flatgeobuf/flatgeobuf/tree/master/src/rust"
 readme = "README.md"
@@ -16,25 +16,25 @@ default = ["http"]
 http = ["http-range-client", "bytes"]
 
 [dependencies]
-flatbuffers = "23.1.21"
+flatbuffers = "23.5.26"
 byteorder = "1.4.3"
 geozero = { version = "0.10.0", default-features = false }
 http-range-client = { version = "0.6.0", optional = true }
 bytes = { version = "1.4.0", optional = true }
-log = "0.4.17"
+log = "0.4.19"
 fallible-streaming-iterator = "0.1.9"
-tempfile = "3.5.0"
+tempfile = "3.7.1"
 
 [dev-dependencies]
 geozero = { version = "0.10.0", default-features = true }
 seek_bufread = "1.2.2"
 rand = "0.8.5"
 hex = "0.4.3"
-criterion = "0.4.0"
-tokio = { version = "1.28.1", default-features = false, features = ["macros"] }
+criterion = "0.5.1"
+tokio = { version = "1.30.0", default-features = false, features = ["macros"] }
 # One test needs SSL support; just use the default system bindings for that.
 reqwest = { version = "0.11.18", default-features = true }
-geo-types = "0.7.9"
+geo-types = "0.7.11"
 
 [[bench]]
 name = "read"
@@ -49,4 +49,3 @@ harness = false
 
 [package.metadata.docs.rs]
 all-features = true
-

--- a/src/rust/README.md
+++ b/src/rust/README.md
@@ -12,11 +12,13 @@ circular interpolations as defined by SQL-MM Part 3.
 ```rust
 use flatgeobuf::*;
 
-let mut filein = BufReader::new(File::open("countries.fgb")?);
-let mut fgb = FgbReader::open(&mut filein)?.select_all()?;
-while let Some(feature) = fgb.next()? {
-    println!("{}", feature.property::<String>("name").unwrap());
-    println!("{}", feature.to_json()?);
+fn main() {
+    let mut filein = BufReader::new(File::open("countries.fgb")?);
+    let mut fgb = FgbReader::open(&mut filein)?.select_all()?;
+    while let Some(feature) = fgb.next()? {
+        println!("{}", feature.property::<String>("name").unwrap());
+        println!("{}", feature.to_json()?);
+    }
 }
 ```
 
@@ -24,14 +26,16 @@ With async HTTP client:
 ```rust
 use flatgeobuf::*;
 
-let mut fgb = HttpFgbReader::open("https://flatgeobuf.org/test/data/countries.fgb")
-    .await?;
-    .select_bbox(8.8, 47.2, 9.5, 55.3)
-    .await?;
-while let Some(feature) = fgb.next().await? {
-    let props = feature.properties()?;
-    println!("{}", props["name"]);
-    println!("{}", feature.to_wkt()?);
+async fn process() {
+    let mut fgb = HttpFgbReader::open("https://flatgeobuf.org/test/data/countries.fgb")
+        .await?
+        .select_bbox(8.8, 47.2, 9.5, 55.3)
+        .await?;
+    while let Some(feature) = fgb.next().await? {
+        let props = feature.properties()?;
+        println!("{}", props["name"]);
+        println!("{}", feature.to_wkt()?);
+    }
 }
 ```
 

--- a/src/rust/benches/geojson.rs
+++ b/src/rust/benches/geojson.rs
@@ -52,18 +52,18 @@ fn fgb_bbox_to_geojson_dev_null() -> Result<()> {
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("fgb_to_geojson", |b| b.iter(|| fgb_to_geojson()));
+    c.bench_function("fgb_to_geojson", |b| b.iter(fgb_to_geojson));
     c.bench_function("fgb_to_geojson_unchecked", |b| {
-        b.iter(|| fgb_to_geojson_unchecked())
+        b.iter(fgb_to_geojson_unchecked)
     });
     c.bench_function("fgb_to_geojson_dev_null", |b| {
-        b.iter(|| fgb_to_geojson_dev_null())
+        b.iter(fgb_to_geojson_dev_null)
     });
     c.bench_function("fgb_to_geojson_dev_null_unchecked", |b| {
-        b.iter(|| fgb_to_geojson_dev_null_unchecked())
+        b.iter(fgb_to_geojson_dev_null_unchecked)
     });
     c.bench_function("fgb_bbox_to_geojson_dev_null", |b| {
-        b.iter(|| fgb_bbox_to_geojson_dev_null())
+        b.iter(fgb_bbox_to_geojson_dev_null)
     });
 }
 

--- a/src/rust/benches/read.rs
+++ b/src/rust/benches/read.rs
@@ -65,14 +65,14 @@ fn read_bbox_seq() -> Result<()> {
 // }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("read_fgb", |b| b.iter(|| read_fgb()));
+    c.bench_function("read_fgb", |b| b.iter(read_fgb));
     c.bench_function("read_fgb_process_geom", |b| {
-        b.iter(|| read_fgb_process_geom())
+        b.iter(read_fgb_process_geom)
     });
-    c.bench_function("read_fgb_unchecked", |b| b.iter(|| read_fgb_unchecked()));
-    c.bench_function("read_fgb_seq", |b| b.iter(|| read_fgb_seq()));
-    c.bench_function("read_bbox", |b| b.iter(|| read_bbox()));
-    c.bench_function("read_bbox_seq", |b| b.iter(|| read_bbox_seq()));
+    c.bench_function("read_fgb_unchecked", |b| b.iter(read_fgb_unchecked));
+    c.bench_function("read_fgb_seq", |b| b.iter(read_fgb_seq));
+    c.bench_function("read_bbox", |b| b.iter(read_bbox));
+    c.bench_function("read_bbox_seq", |b| b.iter(read_bbox_seq));
     // c.bench_function("select_bbox", move |b| {
     //     b.iter_with_setup(
     //         || read_header("../../test/data/countries.fgb").unwrap(),

--- a/src/rust/fgbutil/Cargo.toml
+++ b/src/rust/fgbutil/Cargo.toml
@@ -1,14 +1,13 @@
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
 [package]
 name = "fgbutil"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-clap = { version = "3.1.0", features = ["derive"] }
-geozero = { version = "0.9.5", default-features = true }
-
-[dependencies.flatgeobuf]
-path = ".."
-
-[workspace]
-members = ["."]
+clap = { version = "4.3.21", features = ["derive"] }
+flatgeobuf = { path = ".." }
+geozero = "0.10.0"

--- a/src/rust/fgbutil/src/main.rs
+++ b/src/rust/fgbutil/src/main.rs
@@ -1,12 +1,12 @@
 use clap::{ArgEnum, Args, Parser, Subcommand};
 use flatgeobuf::*;
 use geozero::error::Result;
-use geozero::geojson::GeoJsonWriter;
 use geozero::geojson::read_geojson_fc;
+use geozero::geojson::GeoJsonWriter;
 use geozero::FeatureProcessor;
 use geozero::GeozeroDatasource;
 use std::fs::File;
-use std::io::{Read, BufRead, BufReader, BufWriter, Write};
+use std::io::{BufRead, BufReader, BufWriter, Read, Write};
 
 pub struct GeoJsonReaderStream<'a, R: Read>(pub &'a mut R);
 
@@ -135,7 +135,7 @@ fn transform(
 fn info(mut input: impl BufRead, args: &Info) -> Result<()> {
     let mut fgb = FgbReader::open(&mut input)?;
 
-    println!("{:#?}", &fgb.header());
+    println!("{:#?}", fgb.header());
 
     if args.index {
         fgb.process_index(&mut GeoJsonWriter::new(&mut std::io::stdout()))?;
@@ -151,7 +151,7 @@ fn info(mut input: impl BufRead, args: &Info) -> Result<()> {
         let mut n = 0;
         while let Some(feature) = fgb.next()? {
             if n == fno {
-                println!("{:#?}", &feature.fbs_feature());
+                println!("{:#?}", feature.fbs_feature());
                 break;
             }
             n += 1;

--- a/src/rust/fuzz/Cargo.toml
+++ b/src/rust/fuzz/Cargo.toml
@@ -1,22 +1,20 @@
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
 [package]
 name = "flatgeobuf-fuzz"
 version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true
 
 [dependencies]
-libfuzzer-sys = "0.3"
-
-[dependencies.flatgeobuf]
-path = ".."
-
-# Prevent this from interfering with workspaces
-[workspace]
-members = ["."]
+libfuzzer-sys = "0.4.6"
+flatgeobuf = { path = ".." }
 
 [[bin]]
 name = "read"

--- a/src/rust/src/feature_writer.rs
+++ b/src/rust/src/feature_writer.rs
@@ -191,7 +191,7 @@ impl<'a> FeatureWriter<'a> {
         );
         self.parts.push(g);
     }
-    pub(crate) fn to_feature(&mut self) -> Vec<u8> {
+    pub(crate) fn finish_to_feature(&mut self) -> Vec<u8> {
         let g = if self.parts.is_empty() {
             self.finish_part();
             self.parts.pop().expect("push in finish_part")
@@ -501,7 +501,7 @@ mod test {
         let mut out: Vec<u8> = Vec::new();
         let feat = FgbFeature {
             header_buf: header(fgb_writer.dataset_type),
-            feature_buf: fgb_writer.to_feature(),
+            feature_buf: fgb_writer.finish_to_feature(),
         };
         // dbg!(&feat.fbs_feature());
         feat.process(&mut GeoJsonWriter::new(&mut out), 0)?;
@@ -515,7 +515,7 @@ mod test {
         let mut out: Vec<u8> = Vec::new();
         let f = FgbFeature {
             header_buf: header(geometry_type),
-            feature_buf: fgb_writer.to_feature(),
+            feature_buf: fgb_writer.finish_to_feature(),
         };
         let mut json_writer = GeoJsonWriter::new(&mut out);
         json_writer.dims.z = with_z;
@@ -634,7 +634,7 @@ mod test {
         let mut out: Vec<u8> = Vec::new();
         let feat = FgbFeature {
             header_buf: header(fgb_writer.dataset_type),
-            feature_buf: fgb_writer.to_feature(),
+            feature_buf: fgb_writer.finish_to_feature(),
         };
         assert_eq!(
             fgb_writer.bbox,

--- a/src/rust/src/feature_writer.rs
+++ b/src/rust/src/feature_writer.rs
@@ -128,8 +128,8 @@ impl<'a> FeatureWriter<'a> {
                 }
                 _ => {
                     return Err(GeozeroError::Geometry(format!(
-                        "Cannot mix geometry types - expected type `{:?}`, actual type `{:?}`",
-                        self.dataset_type, geometry_type
+                        "Cannot mix geometry types - expected type `{:?}`, actual type `{geometry_type:?}`",
+                        self.dataset_type
                     )));
                 }
             }
@@ -156,22 +156,22 @@ impl<'a> FeatureWriter<'a> {
             }
             _ => Some(to_fb_vector!(self, ends)),
         };
-        let z = if self.z.len() > 0 {
+        let z = if !self.z.is_empty() {
             Some(to_fb_vector!(self, z))
         } else {
             None
         };
-        let m = if self.m.len() > 0 {
+        let m = if !self.m.is_empty() {
             Some(to_fb_vector!(self, m))
         } else {
             None
         };
-        let t = if self.t.len() > 0 {
+        let t = if !self.t.is_empty() {
             Some(to_fb_vector!(self, t))
         } else {
             None
         };
-        let tm = if self.tm.len() > 0 {
+        let tm = if !self.tm.is_empty() {
             Some(to_fb_vector!(self, tm))
         } else {
             None
@@ -192,7 +192,7 @@ impl<'a> FeatureWriter<'a> {
         self.parts.push(g);
     }
     pub(crate) fn to_feature(&mut self) -> Vec<u8> {
-        let g = if self.parts.len() == 0 {
+        let g = if self.parts.is_empty() {
             self.finish_part();
             self.parts.pop().expect("push in finish_part")
         } else {
@@ -542,7 +542,7 @@ mod test {
 
         let geojson = r#"{"type": "MultiPoint", "coordinates": [[1,1],[2,2]]}"#;
         assert_eq!(
-            str::from_utf8(&json_to_fbg_to_json(&geojson, GeometryType::MultiPoint)).unwrap(),
+            str::from_utf8(&json_to_fbg_to_json(geojson, GeometryType::MultiPoint)).unwrap(),
             geojson
         );
 
@@ -572,7 +572,7 @@ mod test {
         let geojson = r#"{"type": "LineString", "coordinates": [[1,1,10],[2,2,20]]}"#;
         assert_eq!(
             str::from_utf8(&json_to_fbg_to_json_n(
-                &geojson,
+                geojson,
                 GeometryType::LineString,
                 true
             ))

--- a/src/rust/src/file_reader.rs
+++ b/src/rust/src/file_reader.rs
@@ -322,8 +322,8 @@ impl<'a, T: Read + Seek> GeozeroDatasource for FgbReader<'a, T, FeaturesSelected
 /// # }
 /// ```
 impl<'a, R: Read> FallibleStreamingIterator for FgbReader<'a, R, FeaturesSelected> {
-    type Error = GeozeroError;
     type Item = FgbFeature;
+    type Error = GeozeroError;
 
     fn advance(&mut self) -> Result<()> {
         if self.advance_finished() {
@@ -373,8 +373,8 @@ impl<'a, R: Read> FallibleStreamingIterator for FgbReader<'a, R, FeaturesSelecte
 /// # }
 /// ```
 impl<'a, R: Read + Seek> FallibleStreamingIterator for FgbReader<'a, R, FeaturesSelectedSeek> {
-    type Error = GeozeroError;
     type Item = FgbFeature;
+    type Error = GeozeroError;
 
     fn advance(&mut self) -> Result<()> {
         if self.advance_finished() {

--- a/src/rust/src/file_reader.rs
+++ b/src/rust/src/file_reader.rs
@@ -39,6 +39,11 @@ impl<'a, R: Read> FgbReader<'a, R, Initial> {
     }
 
     /// Open dataset by reading the header information without FlatBuffers verification
+    ///
+    /// # Safety
+    /// This method is unsafe because it does not verify the FlatBuffers header.
+    /// It is still from the Rust safety guarantees perspective, but it may cause
+    /// undefined behavior if the FlatBuffers header is invalid.
     pub unsafe fn open_unchecked(reader: &'a mut R) -> Result<FgbReader<'a, R, Open>> {
         Self::read_header(reader, false)
     }

--- a/src/rust/src/file_reader.rs
+++ b/src/rust/src/file_reader.rs
@@ -42,7 +42,7 @@ impl<'a, R: Read> FgbReader<'a, R, Initial> {
     ///
     /// # Safety
     /// This method is unsafe because it does not verify the FlatBuffers header.
-    /// It is still from the Rust safety guarantees perspective, but it may cause
+    /// It is still safe from the Rust safety guarantees perspective, but it may cause
     /// undefined behavior if the FlatBuffers header is invalid.
     pub unsafe fn open_unchecked(reader: &'a mut R) -> Result<FgbReader<'a, R, Open>> {
         Self::read_header(reader, false)

--- a/src/rust/src/file_reader.rs
+++ b/src/rust/src/file_reader.rs
@@ -412,11 +412,9 @@ impl<'a, R: Read, State> FgbReader<'a, R, State> {
 
     fn read_feature(&mut self) -> Result<()> {
         // Read feature size if not already read in select_all or select_bbox
-        if self.cur_pos != 4 {
-            if self.read_feature_size() {
-                self.finished = true;
-                return Ok(());
-            }
+        if self.cur_pos != 4 && self.read_feature_size() {
+            self.finished = true;
+            return Ok(());
         }
         let sbuf = &self.fbs.feature_buf;
         let feature_size = u32::from_le_bytes([sbuf[0], sbuf[1], sbuf[2], sbuf[3]]) as usize;

--- a/src/rust/src/file_writer.rs
+++ b/src/rust/src/file_writer.rs
@@ -287,7 +287,7 @@ impl<'a> FgbWriter<'a> {
         // Will be replaced with output offset after sorting
         node.offset = self.feat_offsets.len() as u64;
         self.feat_nodes.push(node);
-        let feat_buf = self.feat_writer.to_feature();
+        let feat_buf = self.feat_writer.finish_to_feature();
         let tmpoffset = self
             .feat_offsets
             .last()
@@ -297,14 +297,14 @@ impl<'a> FgbWriter<'a> {
             offset: tmpoffset,
             size: feat_buf.len(),
         });
-        self.tmpout.write(&feat_buf)?;
+        self.tmpout.write_all(&feat_buf)?;
         self.header_args.features_count += 1;
         Ok(())
     }
 
     /// Write the FlatGeobuf dataset (Hilbert sorted)
     pub fn write<W: Write>(mut self, out: &'a mut W) -> Result<()> {
-        out.write(&MAGIC_BYTES)?;
+        out.write_all(&MAGIC_BYTES)?;
 
         let extent = calc_extent(&self.feat_nodes);
 
@@ -319,7 +319,7 @@ impl<'a> FgbWriter<'a> {
         let header = Header::create(&mut self.fbb, &self.header_args);
         self.fbb.finish_size_prefixed(header, None);
         let buf = self.fbb.finished_data();
-        out.write(buf)?;
+        out.write_all(buf)?;
 
         if self.header_args.index_node_size > 0 && !self.feat_nodes.is_empty() {
             // Create sorted index
@@ -345,13 +345,19 @@ impl<'a> FgbWriter<'a> {
         self.tmpout.flush()?;
         let tmpin = File::open(&self.tmpfn)?;
         let mut reader = BufReader::new(tmpin);
-        let mut buf = Vec::with_capacity(2048);
-        for node in &self.feat_nodes {
-            let feat = &self.feat_offsets[node.offset as usize];
-            reader.seek(SeekFrom::Start(feat.offset as u64))?;
-            buf.resize(feat.size, 0);
-            reader.read_exact(&mut buf)?;
-            out.write(&buf)?;
+
+        // Clippy generates a false-positive here, needs a block to disable, see
+        // https://github.com/rust-lang/rust-clippy/issues/9274
+        #[allow(clippy::read_zero_byte_vec)]
+        {
+            let mut buf = Vec::with_capacity(2048);
+            for node in &self.feat_nodes {
+                let feat = &self.feat_offsets[node.offset as usize];
+                reader.seek(SeekFrom::Start(feat.offset as u64))?;
+                buf.resize(feat.size, 0);
+                reader.read_exact(&mut buf)?;
+                out.write_all(&buf)?;
+            }
         }
 
         Ok(())

--- a/src/rust/src/file_writer.rs
+++ b/src/rust/src/file_writer.rs
@@ -319,9 +319,9 @@ impl<'a> FgbWriter<'a> {
         let header = Header::create(&mut self.fbb, &self.header_args);
         self.fbb.finish_size_prefixed(header, None);
         let buf = self.fbb.finished_data();
-        out.write(&buf)?;
+        out.write(buf)?;
 
-        if self.header_args.index_node_size > 0 && self.feat_nodes.len() > 0 {
+        if self.header_args.index_node_size > 0 && !self.feat_nodes.is_empty() {
             // Create sorted index
             hilbert_sort(&mut self.feat_nodes, &extent);
             // Update offsets for index

--- a/src/rust/src/file_writer.rs
+++ b/src/rust/src/file_writer.rs
@@ -157,7 +157,7 @@ impl<'a> FgbWriter<'a> {
         geometry_type: GeometryType,
         options: FgbWriterOptions,
     ) -> Result<Self> {
-        let mut fbb = flatbuffers::FlatBufferBuilder::new();
+        let mut fbb = FlatBufferBuilder::new();
 
         let index_node_size = if options.write_index {
             PackedRTree::DEFAULT_NODE_SIZE
@@ -383,7 +383,7 @@ impl PropertyProcessor for FgbWriter<'_> {
                 return Ok(false);
             }
         }
-        // TODO: check name and type against existing declartion
+        // TODO: check name and type against existing declaration
         self.feat_writer.property(i, colname, colval)
     }
 }

--- a/src/rust/src/file_writer.rs
+++ b/src/rust/src/file_writer.rs
@@ -375,15 +375,11 @@ impl PropertyProcessor for FgbWriter<'_> {
         if i >= self.columns.len() {
             if i == self.columns.len() {
                 info!(
-                    "Undefined property index {}, column: `{}` - adding column declaration",
-                    i, colname
+                    "Undefined property index {i}, column: `{colname}` - adding column declaration"
                 );
                 self.add_column(colname, prop_type(colval), |_, _| {});
             } else {
-                info!(
-                    "Undefined property index {}, column: `{}` - skipping",
-                    i, colname
-                );
+                info!("Undefined property index {i}, column: `{colname}` - skipping");
                 return Ok(false);
             }
         }

--- a/src/rust/src/geometry_reader.rs
+++ b/src/rust/src/geometry_reader.rs
@@ -125,8 +125,7 @@ fn read_geometry_n<P: GeomProcessor>(
         }
         _ => {
             return Err(GeozeroError::Geometry(format!(
-                "Unknown geometry type {:?}",
-                geometry_type
+                "Unknown geometry type {geometry_type:?}"
             )))
         }
     }
@@ -141,22 +140,22 @@ fn read_coordinate<P: GeomProcessor>(
 ) -> Result<()> {
     let xy = geometry.xy().ok_or(GeozeroError::Coord)?;
     let z = if processor.dimensions().z {
-        geometry.z().and_then(|dim| Some(dim.get(offset)))
+        geometry.z().map(|dim| dim.get(offset))
     } else {
         None
     };
     let m = if processor.dimensions().m {
-        geometry.m().and_then(|dim| Some(dim.get(offset)))
+        geometry.m().map(|dim| dim.get(offset))
     } else {
         None
     };
     let t = if processor.dimensions().t {
-        geometry.t().and_then(|dim| Some(dim.get(offset)))
+        geometry.t().map(|dim| dim.get(offset))
     } else {
         None
     };
     let tm = if processor.dimensions().tm {
-        geometry.tm().and_then(|dim| Some(dim.get(offset)))
+        geometry.tm().map(|dim| dim.get(offset))
     } else {
         None
     };
@@ -344,8 +343,7 @@ fn read_curve<P: GeomProcessor>(
             }
             _ => {
                 return Err(GeozeroError::Geometry(format!(
-                    "Unexpected geometry type in curve: {:?}",
-                    geometry_type
+                    "Unexpected geometry type in curve: {geometry_type:?}"
                 )))
             }
         }

--- a/src/rust/src/geometry_reader.rs
+++ b/src/rust/src/geometry_reader.rs
@@ -139,23 +139,24 @@ fn read_coordinate<P: GeomProcessor>(
     idx: usize,
 ) -> Result<()> {
     let xy = geometry.xy().ok_or(GeozeroError::Coord)?;
-    let z = if processor.dimensions().z {
-        geometry.z().map(|dim| dim.get(offset))
+    let dims = processor.dimensions();
+    let z = if dims.z {
+        geometry.z().map(|v| v.get(offset))
     } else {
         None
     };
-    let m = if processor.dimensions().m {
-        geometry.m().map(|dim| dim.get(offset))
+    let m = if dims.m {
+        geometry.m().map(|v| v.get(offset))
     } else {
         None
     };
-    let t = if processor.dimensions().t {
-        geometry.t().map(|dim| dim.get(offset))
+    let t = if dims.t {
+        geometry.t().map(|v| v.get(offset))
     } else {
         None
     };
-    let tm = if processor.dimensions().tm {
-        geometry.tm().map(|dim| dim.get(offset))
+    let tm = if dims.tm {
+        geometry.tm().map(|v| v.get(offset))
     } else {
         None
     };

--- a/src/rust/src/header_generated.rs
+++ b/src/rust/src/header_generated.rs
@@ -1124,13 +1124,13 @@ pub unsafe fn size_prefixed_root_as_header_unchecked(buf: &[u8]) -> Header {
   flatbuffers::size_prefixed_root_unchecked::<Header>(buf)
 }
 #[inline]
-pub fn finish_header_buffer<'a, 'b>(
-    fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+pub fn finish_header_buffer<'a>(
+    fbb: &mut flatbuffers::FlatBufferBuilder<'a>,
     root: flatbuffers::WIPOffset<Header<'a>>) {
   fbb.finish(root, None);
 }
 
 #[inline]
-pub fn finish_size_prefixed_header_buffer<'a, 'b>(fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>, root: flatbuffers::WIPOffset<Header<'a>>) {
+pub fn finish_size_prefixed_header_buffer<'a>(fbb: &mut flatbuffers::FlatBufferBuilder<'a>, root: flatbuffers::WIPOffset<Header<'a>>) {
   fbb.finish_size_prefixed(root, None);
 }

--- a/src/rust/src/http_reader.rs
+++ b/src/rust/src/http_reader.rs
@@ -41,7 +41,7 @@ pub(crate) fn from_http_err(error: HttpError) -> GeozeroError {
 impl HttpFgbReader<Initial> {
     pub async fn open(url: &str) -> Result<HttpFgbReader<Open>> {
         trace!("starting: opening http reader, reading header");
-        let mut client = BufferedHttpRangeClient::new(&url);
+        let mut client = BufferedHttpRangeClient::new(url);
 
         // Because we use a buffered HTTP reader, anything extra we fetch here can
         // be utilized to skip subsequent fetches.
@@ -57,7 +57,7 @@ impl HttpFgbReader<Initial> {
             let prefetched_layers: u32 = 3;
 
             (0..prefetched_layers)
-                .map(|i| assumed_branching_factor.pow(i) * std::mem::size_of::<NodeItem>() as usize)
+                .map(|i| assumed_branching_factor.pow(i) * std::mem::size_of::<NodeItem>())
                 .sum()
         };
 
@@ -71,7 +71,7 @@ impl HttpFgbReader<Initial> {
             .get_range(0, 8, min_req_size)
             .await
             .map_err(from_http_err)?;
-        if !check_magic_bytes(&bytes) {
+        if !check_magic_bytes(bytes) {
             return Err(GeozeroError::GeometryFormat);
         }
         let mut bytes = BytesMut::from(

--- a/src/rust/src/http_reader.rs
+++ b/src/rust/src/http_reader.rs
@@ -65,7 +65,7 @@ impl HttpFgbReader<Initial> {
         // fetch an extra kb rather than have to issue a second request.
         let assumed_header_size = 2024;
         let min_req_size = assumed_header_size + prefetch_index_bytes;
-        debug!("fetching header. min_req_size: {} (assumed_header_size: {}, prefetched_index_bytes: {})", min_req_size, assumed_header_size, prefetch_index_bytes);
+        debug!("fetching header. min_req_size: {min_req_size} (assumed_header_size: {assumed_header_size}, prefetched_index_bytes: {prefetch_index_bytes})");
 
         let bytes = client
             .get_range(0, 8, min_req_size)

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -104,6 +104,10 @@ pub mod reader_state {
 
 // Re-export used traits
 pub use fallible_streaming_iterator::FallibleStreamingIterator;
+
+// Re-export GeoZero to help avoid version conflicts
+pub use geozero;
+// For backward compatibility, keep individual trait re-exports
 pub use geozero::{FeatureAccess, FeatureProperties, GeozeroGeometry};
 
 pub const VERSION: u8 = 3;

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -65,18 +65,20 @@
 //! ```
 //!
 
+#![allow(clippy::manual_range_contains)]
+
 #[cfg(feature = "http")]
 #[macro_use]
 extern crate log;
 
-#[allow(unused_imports, non_snake_case)]
+#[allow(unused_imports, non_snake_case, clippy::all)]
 #[rustfmt::skip]
 mod feature_generated;
 mod feature_writer;
 mod file_reader;
 mod file_writer;
 mod geometry_reader;
-#[allow(unused_imports, non_snake_case)]
+#[allow(unused_imports, non_snake_case, clippy::all)]
 #[rustfmt::skip]
 mod header_generated;
 #[cfg(feature = "http")]

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -70,14 +70,14 @@
 extern crate log;
 
 #[allow(unused_imports, non_snake_case)]
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 mod feature_generated;
 mod feature_writer;
 mod file_reader;
 mod file_writer;
 mod geometry_reader;
 #[allow(unused_imports, non_snake_case)]
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 mod header_generated;
 #[cfg(feature = "http")]
 mod http_reader;

--- a/src/rust/src/packed_r_tree.rs
+++ b/src/rust/src/packed_r_tree.rs
@@ -604,7 +604,7 @@ impl PackedRTree {
                 match (queue.back_mut(), node_item.offset as usize) {
                     // There is an existing node for this level, and it's close to this node.
                     // Merge the ranges to avoid an extra request
-                    (Some(mut tail), offset)
+                    (Some(tail), offset)
                         if tail.level == next.level - 1
                             && offset < tail.nodes.end + combine_request_threshold =>
                     {
@@ -728,7 +728,7 @@ fn tree_2items() -> Result<()> {
     assert!(nodes[1].intersects(&NodeItem::new(2.0, 2.0, 3.0, 3.0)));
     hilbert_sort(&mut nodes, &extent);
     let mut offset = 0;
-    for mut node in &mut nodes {
+    for node in &mut nodes {
         node.offset = offset;
         offset += size_of::<NodeItem>() as u64;
     }
@@ -766,7 +766,7 @@ fn tree_19items_roundtrip_stream_search() -> Result<()> {
     let extent = calc_extent(&nodes);
     hilbert_sort(&mut nodes, &extent);
     let mut offset = 0;
-    for mut node in &mut nodes {
+    for node in &mut nodes {
         node.offset = offset;
         offset += size_of::<NodeItem>() as u64;
     }
@@ -873,7 +873,7 @@ fn tree_processing() -> Result<()> {
     nodes.push(NodeItem::new(2.0, 2.0, 3.0, 3.0));
     let extent = calc_extent(&nodes);
     let mut offset = 0;
-    for mut node in &mut nodes {
+    for node in &mut nodes {
         node.offset = offset;
         offset += size_of::<NodeItem>() as u64;
     }

--- a/src/rust/src/packed_r_tree.rs
+++ b/src/rust/src/packed_r_tree.rs
@@ -549,7 +549,7 @@ impl PackedRTree {
         let item = NodeItem::new(min_x, min_y, max_x, max_y);
         let level_bounds = PackedRTree::generate_level_bounds(num_items, node_size);
         let leaf_nodes_offset = level_bounds.first().ok_or(GeozeroError::GeometryIndex)?.0;
-        debug!("http_stream_search - index_begin: {}, num_items: {}, node_size: {}, level_bounds: {:?}, GPS bounds:[({}, {}), ({},{})]", index_begin, num_items, node_size, &level_bounds, min_x, min_y, max_x, max_y);
+        debug!("http_stream_search - index_begin: {index_begin}, num_items: {num_items}, node_size: {node_size}, level_bounds: {level_bounds:?}, GPS bounds:[({min_x}, {min_y}), ({max_x},{max_y})]");
 
         #[derive(Debug, PartialEq, Eq)]
         struct NodeRange {
@@ -566,8 +566,7 @@ impl PackedRTree {
 
         while let Some(next) = queue.pop_front() {
             debug!(
-                "popped node: {:?},  remaining queue len: {}",
-                next,
+                "popped node: {next:?},  remaining queue len: {}",
                 queue.len()
             );
             let node_index = next.nodes.start;
@@ -622,11 +621,10 @@ impl PackedRTree {
                             .map(|head| head.level == next.level - 1)
                             .unwrap_or(false)
                         {
-                            debug!("requesting new NodeRange for offset: {} rather than merging with distant NodeRange: {:?}", offset, &tail);
+                            debug!("requesting new NodeRange for offset: {offset} rather than merging with distant NodeRange: {tail:?}");
                         } else {
                             debug!(
-                                "pushing new level for NodeRange: {:?} onto Queue with tail: {:?}",
-                                &node_range,
+                                "pushing new level for NodeRange: {node_range:?} onto Queue with tail: {:?}",
                                 queue.back()
                             );
                         }

--- a/src/rust/src/packed_r_tree.rs
+++ b/src/rust/src/packed_r_tree.rs
@@ -241,9 +241,9 @@ fn hilbert(x: u32, y: u32) -> u32 {
     i1 = (i1 | (i1 << 2)) & 0x33333333;
     i1 = (i1 | (i1 << 1)) & 0x55555555;
 
-    let value = (i1 << 1) | i0;
+    
 
-    value
+    (i1 << 1) | i0
 }
 
 fn hilbert_bbox(r: &NodeItem, hilbert_max: u32, extent: &NodeItem) -> u32 {
@@ -355,7 +355,7 @@ impl PackedRTree {
     fn read_data(&mut self, data: &mut dyn Read) -> Result<()> {
         read_node_vec(&mut self.node_items, data)?;
         for node in &self.node_items {
-            self.extent.expand(&node)
+            self.extent.expand(node)
         }
         Ok(())
     }
@@ -424,7 +424,7 @@ impl PackedRTree {
         let mut tree = PackedRTree {
             extent: NodeItem::create(0),
             node_items: Vec::new(),
-            num_items: num_items,
+            num_items,
             num_nodes: 0,
             node_size: 0,
             level_bounds: Vec::new(),
@@ -462,7 +462,7 @@ impl PackedRTree {
             // search through child nodes
             for pos in node_index..end {
                 let node_item = &self.node_items[pos];
-                if !n.intersects(&node_item) {
+                if !n.intersects(node_item) {
                     continue;
                 }
                 if is_leaf_node {
@@ -493,7 +493,7 @@ impl PackedRTree {
         let num_nodes = level_bounds.first().ok_or(GeozeroError::GeometryIndex)?.1;
 
         // current position must be start of index
-        let index_base = data.seek(SeekFrom::Current(0))?;
+        let index_base = data.stream_position()?;
 
         // use ordered search queue to make index traversal in sequential order
         let mut queue = VecDeque::new();
@@ -513,7 +513,7 @@ impl PackedRTree {
             for pos in node_index..end {
                 let node_pos = pos - node_index;
                 let node_item = &node_items[node_pos];
-                if !item.intersects(&node_item) {
+                if !item.intersects(node_item) {
                     continue;
                 }
                 if is_leaf_node {
@@ -586,7 +586,7 @@ impl PackedRTree {
             for pos in node_index..end {
                 let node_pos = pos - node_index;
                 let node_item = &node_items[node_pos];
-                if !item.intersects(&node_item) {
+                if !item.intersects(node_item) {
                     continue;
                 }
                 if is_leaf_node {
@@ -695,7 +695,7 @@ mod inspect {
                         processor.property(0, "levelno", &ColumnValue::ULong(levelno as u64))?;
                     let _ = processor.property(1, "pos", &ColumnValue::ULong(pos as u64))?;
                     let _ =
-                        processor.property(2, "offset", &ColumnValue::ULong(node.offset as u64))?;
+                        processor.property(2, "offset", &ColumnValue::ULong(node.offset))?;
                     processor.properties_end()?;
                     processor.geometry_begin()?;
                     processor.polygon_begin(true, 1, 0)?;

--- a/src/rust/src/properties_reader.rs
+++ b/src/rust/src/properties_reader.rs
@@ -71,7 +71,7 @@ impl geozero::FeatureProperties for FgbFeature {
                     ColumnType::Int => {
                         finish = reader.property(
                             i,
-                            &column.name(),
+                            column.name(),
                             &ColumnValue::Int(LittleEndian::read_i32(&bytes[offset..offset + 4])),
                         )?;
                         offset += size_of::<i32>();
@@ -79,7 +79,7 @@ impl geozero::FeatureProperties for FgbFeature {
                     ColumnType::Long => {
                         finish = reader.property(
                             i,
-                            &column.name(),
+                            column.name(),
                             &ColumnValue::Long(LittleEndian::read_i64(&bytes[offset..offset + 8])),
                         )?;
                         offset += size_of::<i64>();
@@ -87,7 +87,7 @@ impl geozero::FeatureProperties for FgbFeature {
                     ColumnType::ULong => {
                         finish = reader.property(
                             i,
-                            &column.name(),
+                            column.name(),
                             &ColumnValue::ULong(LittleEndian::read_u64(&bytes[offset..offset + 8])),
                         )?;
                         offset += size_of::<u64>();
@@ -95,7 +95,7 @@ impl geozero::FeatureProperties for FgbFeature {
                     ColumnType::Double => {
                         finish = reader.property(
                             i,
-                            &column.name(),
+                            column.name(),
                             &ColumnValue::Double(LittleEndian::read_f64(
                                 &bytes[offset..offset + 8],
                             )),
@@ -107,7 +107,7 @@ impl geozero::FeatureProperties for FgbFeature {
                         offset += size_of::<u32>();
                         finish = reader.property(
                             i,
-                            &column.name(),
+                            column.name(),
                             &ColumnValue::String(
                                 // unsafe variant without UTF-8 checking would be faster...
                                 str::from_utf8(&bytes[offset..offset + len]).map_err(|_| {
@@ -120,7 +120,7 @@ impl geozero::FeatureProperties for FgbFeature {
                     ColumnType::Byte => {
                         finish = reader.property(
                             i,
-                            &column.name(),
+                            column.name(),
                             &ColumnValue::Byte(bytes[offset] as i8),
                         )?;
                         offset += size_of::<i8>();
@@ -128,7 +128,7 @@ impl geozero::FeatureProperties for FgbFeature {
                     ColumnType::UByte => {
                         finish = reader.property(
                             i,
-                            &column.name(),
+                            column.name(),
                             &ColumnValue::UByte(bytes[offset]),
                         )?;
                         offset += size_of::<u8>();
@@ -136,7 +136,7 @@ impl geozero::FeatureProperties for FgbFeature {
                     ColumnType::Bool => {
                         finish = reader.property(
                             i,
-                            &column.name(),
+                            column.name(),
                             &ColumnValue::Bool(bytes[offset] != 0),
                         )?;
                         offset += size_of::<u8>();
@@ -144,7 +144,7 @@ impl geozero::FeatureProperties for FgbFeature {
                     ColumnType::Short => {
                         finish = reader.property(
                             i,
-                            &column.name(),
+                            column.name(),
                             &ColumnValue::Short(LittleEndian::read_i16(&bytes[offset..offset + 2])),
                         )?;
                         offset += size_of::<i16>();
@@ -152,7 +152,7 @@ impl geozero::FeatureProperties for FgbFeature {
                     ColumnType::UShort => {
                         finish = reader.property(
                             i,
-                            &column.name(),
+                            column.name(),
                             &ColumnValue::UShort(LittleEndian::read_u16(
                                 &bytes[offset..offset + 2],
                             )),
@@ -162,7 +162,7 @@ impl geozero::FeatureProperties for FgbFeature {
                     ColumnType::UInt => {
                         finish = reader.property(
                             i,
-                            &column.name(),
+                            column.name(),
                             &ColumnValue::UInt(LittleEndian::read_u32(&bytes[offset..offset + 4])),
                         )?;
                         offset += size_of::<u32>();
@@ -170,7 +170,7 @@ impl geozero::FeatureProperties for FgbFeature {
                     ColumnType::Float => {
                         finish = reader.property(
                             i,
-                            &column.name(),
+                            column.name(),
                             &ColumnValue::Float(LittleEndian::read_f32(&bytes[offset..offset + 4])),
                         )?;
                         offset += size_of::<f32>();
@@ -180,7 +180,7 @@ impl geozero::FeatureProperties for FgbFeature {
                         offset += size_of::<u32>();
                         finish = reader.property(
                             i,
-                            &column.name(),
+                            column.name(),
                             &ColumnValue::Json(
                                 // JSON may be represented using UTF-8, UTF-16, or UTF-32. The default encoding is UTF-8.
                                 str::from_utf8(&bytes[offset..offset + len]).map_err(|_| {
@@ -195,7 +195,7 @@ impl geozero::FeatureProperties for FgbFeature {
                         offset += size_of::<u32>();
                         finish = reader.property(
                             i,
-                            &column.name(),
+                            column.name(),
                             &ColumnValue::DateTime(
                                 // unsafe variant without UTF-8 checking would be faster...
                                 str::from_utf8(&bytes[offset..offset + len]).map_err(|_| {
@@ -210,7 +210,7 @@ impl geozero::FeatureProperties for FgbFeature {
                         offset += size_of::<u32>();
                         finish = reader.property(
                             i,
-                            &column.name(),
+                            column.name(),
                             &ColumnValue::Binary(&bytes[offset..offset + len]),
                         )?;
                         offset += len;

--- a/src/rust/tests/http_read.rs
+++ b/src/rust/tests/http_read.rs
@@ -81,9 +81,7 @@ mod http {
         let expected_error_text = "error trying to connect";
         assert!(
             error_text.contains(expected_error_text),
-            "expected to find {} in {}",
-            expected_error_text,
-            error_text
+            "expected to find {expected_error_text} in {error_text}"
         );
     }
 }

--- a/src/rust/tests/http_read.rs
+++ b/src/rust/tests/http_read.rs
@@ -75,7 +75,8 @@ mod http {
             fgb.err().unwrap().to_string(),
             "http status 404".to_string()
         );
-        let url = "http://wrong.sourcepole.ch/countries.fgb";
+
+        let url = "https://wrong.example.com/countries.fgb";
         let fgb = HttpFgbReader::open(url).await;
         let error_text = fgb.err().unwrap().to_string();
         let expected_error_text = "error trying to connect";

--- a/src/rust/tests/read.rs
+++ b/src/rust/tests/read.rs
@@ -40,10 +40,10 @@ fn read_file_low_level() -> Result<()> {
     let safe_vec: Vec<f64> = header.envelope().unwrap().into_iter().collect();
     assert_eq!(safe_vec, &[-180.0, -85.609038, 180.0, 83.64513]);
     assert_eq!(header.geometry_type(), GeometryType::MultiPolygon);
-    assert_eq!(header.has_t(), false);
-    assert_eq!(header.has_m(), false);
-    assert_eq!(header.has_t(), false);
-    assert_eq!(header.has_tm(), false);
+    assert!(!header.has_t());
+    assert!(!header.has_m());
+    assert!(!header.has_t());
+    assert!(!header.has_tm());
     assert!(header.columns().is_some());
     let columns = header.columns().unwrap();
     assert_eq!(columns.len(), 2);
@@ -432,7 +432,7 @@ fn geomcollection_layer() -> Result<()> {
 }
 
 fn read_layer_geometry(fname: &str, with_z: bool) -> Result<String> {
-    let mut filein = BufReader::new(File::open(&format!("../../test/data/{}", fname))?);
+    let mut filein = BufReader::new(File::open(format!("../../test/data/{fname}"))?);
     let mut fgb = FgbReader::open(&mut filein)?.select_all()?;
     let feature = fgb.next()?.unwrap();
     assert!(feature.geometry().is_some());
@@ -556,10 +556,10 @@ fn multi_dim() -> Result<()> {
     let fgb = FgbReader::open(&mut filein)?;
     let geometry_type = fgb.header().geometry_type();
     assert_eq!(geometry_type, GeometryType::MultiPolygon);
-    assert_eq!(fgb.header().has_z(), true);
-    assert_eq!(fgb.header().has_m(), false);
-    assert_eq!(fgb.header().has_t(), false);
-    assert_eq!(fgb.header().has_tm(), false);
+    assert!(fgb.header().has_z());
+    assert!(!fgb.header().has_m());
+    assert!(!fgb.header().has_t());
+    assert!(!fgb.header().has_tm());
     assert_eq!(fgb.header().features_count(), 87);
 
     let mut fgb = fgb.select_all()?;

--- a/src/rust/tests/read.rs
+++ b/src/rust/tests/read.rs
@@ -290,7 +290,7 @@ fn file_reader() -> Result<()> {
         assert_eq!(&props["id"], "DNK");
         assert_eq!(&props["name"], "Denmark");
     } else {
-        assert!(false, "find failed");
+        panic!("find failed");
     }
 
     Ok(())

--- a/src/rust/tests/svg.rs
+++ b/src/rust/tests/svg.rs
@@ -35,18 +35,18 @@ fn svg_writer<'a, W: Write>(
 }
 
 trait GeomToSvg {
-    fn to_svg<'a, W: Write>(
+    fn to_svg<W: Write>(
         &self,
-        out: &'a mut W,
+        out: &mut W,
         geometry_type: GeometryType,
         invert_y: bool,
     ) -> Result<()>;
 }
 
 impl GeomToSvg for Geometry<'_> {
-    fn to_svg<'a, W: Write>(
+    fn to_svg<W: Write>(
         &self,
-        out: &'a mut W,
+        out: &mut W,
         geometry_type: GeometryType,
         invert_y: bool,
     ) -> Result<()> {
@@ -56,9 +56,9 @@ impl GeomToSvg for Geometry<'_> {
 }
 
 trait FeatureToSvg {
-    fn to_svg<'a, W: Write>(
+    fn to_svg<W: Write>(
         &self,
-        out: &'a mut W,
+        out: &mut W,
         geometry_type: GeometryType,
         invert_y: bool,
     ) -> Result<()>;
@@ -66,9 +66,9 @@ trait FeatureToSvg {
 
 impl FeatureToSvg for Feature<'_> {
     /// Convert feature to SVG
-    fn to_svg<'a, W: Write>(
+    fn to_svg<W: Write>(
         &self,
-        out: &'a mut W,
+        out: &mut W,
         geometry_type: GeometryType,
         invert_y: bool,
     ) -> Result<()> {
@@ -78,7 +78,7 @@ impl FeatureToSvg for Feature<'_> {
     }
 }
 
-fn feature_from_u8<'a>(buf: &'a [u8], loc: usize) -> Feature<'a> {
+fn feature_from_u8(buf: &[u8], loc: usize) -> Feature<'_> {
     unsafe { Feature::init_from_table(flatbuffers::Table::new(buf, loc)) }
 }
 

--- a/src/rust/tests/write.rs
+++ b/src/rust/tests/write.rs
@@ -35,7 +35,7 @@ fn write_file() -> std::io::Result<()> {
     let header = Header::create(&mut fbb, &header_args);
     fbb.finish_size_prefixed(header, None);
     let buf = fbb.finished_data();
-    file.write(&buf)?;
+    file.write(buf)?;
 
     for point in points {
         let mut fbb = flatbuffers::FlatBufferBuilder::new();
@@ -58,7 +58,7 @@ fn write_file() -> std::io::Result<()> {
         let buf = fbb.finished_data();
         assert_eq!(buf.len(), 64);
 
-        file.write(&buf)?;
+        file.write(buf)?;
     }
 
     Ok(())
@@ -82,12 +82,12 @@ fn verify_header() {
     let buf = builder.finished_data();
 
     // verify
-    let header = size_prefixed_root_as_header(&buf).unwrap();
+    let header = size_prefixed_root_as_header(buf).unwrap();
     assert_eq!(header.features_count(), 1);
 
     assert!(
         root_as_header(&buf[4..]).is_err(),
-        "Verfication without size prefix fails"
+        "Verification without size prefix fails"
     );
 }
 

--- a/src/rust/tests/write.rs
+++ b/src/rust/tests/write.rs
@@ -14,7 +14,7 @@ fn write_file() -> std::io::Result<()> {
     let points = [[1.0, 1.0], [2.0, 2.0]];
 
     const MAGIC_BYTES: [u8; 8] = [b'f', b'g', b'b', 3, b'f', b'g', b'b', 0];
-    file.write(&MAGIC_BYTES)?;
+    file.write_all(&MAGIC_BYTES)?;
 
     let mut fbb = flatbuffers::FlatBufferBuilder::new();
     let column_args = ColumnArgs {
@@ -35,7 +35,7 @@ fn write_file() -> std::io::Result<()> {
     let header = Header::create(&mut fbb, &header_args);
     fbb.finish_size_prefixed(header, None);
     let buf = fbb.finished_data();
-    file.write(buf)?;
+    file.write_all(buf)?;
 
     for point in points {
         let mut fbb = flatbuffers::FlatBufferBuilder::new();
@@ -58,7 +58,7 @@ fn write_file() -> std::io::Result<()> {
         let buf = fbb.finished_data();
         assert_eq!(buf.len(), 64);
 
-        file.write(buf)?;
+        file.write_all(buf)?;
     }
 
     Ok(())


### PR DESCRIPTION
* Re-export the entire geozero because it has a number of other used traits like Error, so reexporting partial geozero creates more problem than solves
* Switch all crates to 2021 edition
* Cleanup crate.toml - we may want to switch to a proper workspace here
* bump all dependency versions to latest
* Address some clippy warnings