### PR TITLE
Rust reader/writers can own their i/o stream

### DIFF
--- a/src/rust/CHANGELOG.md
+++ b/src/rust/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Breaking: Remove lifetimes from FgbReader/FgbWriter
+- FgbReader/FgbWriter as well as borrow, can now own their inner reader/writer
+
 ## [3.26.0] - 2023-07-08
 
 - Upgrade to geozero 0.10

--- a/src/rust/benches/read.rs
+++ b/src/rust/benches/read.rs
@@ -66,9 +66,7 @@ fn read_bbox_seq() -> Result<()> {
 
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("read_fgb", |b| b.iter(read_fgb));
-    c.bench_function("read_fgb_process_geom", |b| {
-        b.iter(read_fgb_process_geom)
-    });
+    c.bench_function("read_fgb_process_geom", |b| b.iter(read_fgb_process_geom));
     c.bench_function("read_fgb_unchecked", |b| b.iter(read_fgb_unchecked));
     c.bench_function("read_fgb_seq", |b| b.iter(read_fgb_seq));
     c.bench_function("read_bbox", |b| b.iter(read_bbox));

--- a/src/rust/src/file_writer.rs
+++ b/src/rust/src/file_writer.rs
@@ -303,7 +303,7 @@ impl<'a> FgbWriter<'a> {
     }
 
     /// Write the FlatGeobuf dataset (Hilbert sorted)
-    pub fn write<W: Write>(mut self, out: &'a mut W) -> Result<()> {
+    pub fn write(mut self, mut out: impl Write) -> Result<()> {
         out.write_all(&MAGIC_BYTES)?;
 
         let extent = calc_extent(&self.feat_nodes);
@@ -338,7 +338,7 @@ impl<'a> FgbWriter<'a> {
                 })
                 .collect();
             let tree = PackedRTree::build(&index_nodes, &extent, self.header_args.index_node_size)?;
-            tree.stream_write(out)?;
+            tree.stream_write(&mut out)?;
         }
 
         // Copy features from temp file in sort order

--- a/src/rust/tests/read.rs
+++ b/src/rust/tests/read.rs
@@ -319,9 +319,7 @@ fn read_etrs89() -> Result<()> {
 
 #[test]
 fn reader_type() -> Result<()> {
-    fn get_opened_reader<R: Read + Seek>(
-        reader: &mut R,
-    ) -> Result<FgbReader<R, reader_state::Open>> {
+    fn get_opened_reader<R: Read + Seek>(reader: R) -> Result<FgbReader<R, reader_state::Open>> {
         FgbReader::open(reader)
     }
     let mut filein = BufReader::new(File::open("../../test/data/countries.fgb")?);
@@ -329,7 +327,7 @@ fn reader_type() -> Result<()> {
     assert_eq!(fgb.header().features_count(), 179);
 
     fn get_feature_reader<R: Read + Seek>(
-        reader: &mut R,
+        reader: R,
     ) -> Result<FgbReader<R, reader_state::FeaturesSelectedSeek>> {
         FgbReader::open(reader)?.select_all()
     }


### PR DESCRIPTION
Similar to https://github.com/georust/geozero/pull/162, `impl Write` is strictly more general than `&mut impl Write`

Note that this is a breaking change because it changes the generic params of the FgbReader/Writer type.


