### PR TITLE
Rust: fix `size` inconsistency with `linestring_begin`

### DIFF
--- a/src/rust/src/geometry_reader.rs
+++ b/src/rust/src/geometry_reader.rs
@@ -284,7 +284,7 @@ fn read_polygon<P: GeomProcessor>(
         // single ring
         processor.polygon_begin(tagged, 1, idx)?;
         let xy = geometry.xy().ok_or(GeozeroError::Coord)?;
-        processor.linestring_begin(false, xy.len(), 0)?;
+        processor.linestring_begin(false, xy.len() / 2, 0)?;
         read_coords(processor, geometry, 0, xy.len())?;
         processor.linestring_end(false, 0)?;
         processor.polygon_end(tagged, idx)?;
@@ -323,7 +323,7 @@ fn read_curve<P: GeomProcessor>(
         match geometry_type {
             GeometryType::LineString => {
                 let xy = geometry.xy().ok_or(GeozeroError::Coord)?;
-                processor.linestring_begin(false, xy.len(), i)?;
+                processor.linestring_begin(false, xy.len() / 2, i)?;
                 read_coords(processor, &geometry, 0, xy.len())?;
                 processor.linestring_end(false, i)?;
             }


### PR DESCRIPTION
There's a subtle inconsistency of the `size` in `linestring_begin`. Geozero documents `size` to be the number of coordinates (i.e. not multiplied by 2 in the case of XY dimensions), but there are a couple cases in `linestring_begin` where the length is not divided by 2.

I hit this while implementing reading FlatGeobuf to GeoArrow in https://github.com/kylebarron/geoarrow-rs/pull/157, because I use `size` to add that number into the "offsets" array. I could alternately compute the effective size myself in `linestring_end` by checking the previously-known offset before this linestring, but if I'm able to trust the accuracy of `size` in the `*_begin` methods, that's a little easier.

With this change a test in my repo in the linked PR passes. Do you want me to add a test in this PR?