### PR TITLE
[rust] benchmarks for reading via HTTP

### DIFF
--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -30,15 +30,21 @@ geozero = { version = "0.11.0", default-features = true }
 seek_bufread = "1.2.2"
 rand = "0.8.5"
 hex = "0.4.3"
-criterion = "0.5.1"
-tokio = { version = "1.30.0", default-features = false, features = ["macros"] }
+criterion = { version = "0.5.1", features = ["async_tokio"] }
+tokio = { version = "1.30.0", features = ["rt-multi-thread"] }
 # One test needs SSL support; just use the default system bindings for that.
 reqwest = { version = "0.11.18", default-features = true }
 geo-types = "0.7.11"
+yocalhost = "0.1.0"
 
 [[bench]]
 name = "read"
 harness = false
+
+[[bench]]
+name = "http_read"
+harness = false
+
 [[bench]]
 name = "geojson"
 harness = false

--- a/src/rust/benches/http_read.rs
+++ b/src/rust/benches/http_read.rs
@@ -1,0 +1,74 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use flatgeobuf::HttpFgbReader;
+use geozero::error::Result;
+
+// 205KB
+const SMALL_URL: &str = "http://localhost:8001/countries.fgb";
+
+// 13MB
+const MEDIUM_URL: &str = "http://localhost:8001/UScounties.fgb";
+
+async fn select_all(url: &str, expected_feature_count: usize) -> Result<()> {
+    let reader = HttpFgbReader::open(url).await.unwrap();
+    let mut stream = reader.select_all().await.unwrap();
+
+    let mut count = 0;
+    while let Some(feature) = stream.next().await.transpose() {
+        let _feature = feature.unwrap();
+        count += 1
+    }
+    assert_eq!(count, expected_feature_count);
+    Ok(())
+}
+
+async fn select_bbox(url: &str, expected_feature_count: usize) {
+    let reader = HttpFgbReader::open(url).await.unwrap();
+    let mut stream = reader.select_bbox(-86.0, 10.0, -85.0, 40.0).await.unwrap();
+
+    let mut count = 0;
+    while let Some(feature) = stream.next().await.transpose() {
+        let _feature = feature.unwrap();
+        count += 1
+    }
+    assert_eq!(count, expected_feature_count);
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    use std::time::Duration;
+    use yocalhost::ThrottledServer;
+
+    let port = 8001;
+
+    // Apply limits to simulate an "average" connection for benchmarks
+    let latency = Duration::from_millis(100);
+    let bytes_per_second = 50_000_000 / 8;
+
+    let web_root = "../../test/data";
+    let server = ThrottledServer::new(port, latency, bytes_per_second, web_root);
+
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    runtime.spawn(async move {
+        server.serve().await;
+    });
+
+    for (name, url, total_count, bbox_count) in [
+        ("small", SMALL_URL, 179, 4),
+        ("medium", MEDIUM_URL, 3221, 140),
+    ] {
+        c.bench_function(&format!("{name} select_all"), |b| {
+            let runtime = tokio::runtime::Runtime::new().unwrap();
+            b.to_async(runtime)
+                .iter(|| select_all(url, total_count))
+        });
+
+        c.bench_function(&format!("{name} select_bbox"), |b| {
+            let runtime = tokio::runtime::Runtime::new().unwrap();
+            b.to_async(runtime)
+                .iter(|| select_bbox(url, bbox_count))
+        });
+    }
+}
+
+criterion_group!(name=benches; config=Criterion::default().sample_size(10); targets=criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
I've been digging into the http reader's performance characteristics as part of https://github.com/flatgeobuf/flatgeobuf/issues/94

For (somewhat) reproducible results, a local http server is used to host the files.
For (somewhat) realistic measurements, the server induces artificial latency and bandwidth constraints.

There's still some noise in the measurements, but it's much better to the point of being actually useful in the work I've been doing. For example, I still regularly see 1-5% differences in measurements. But without the local server, I was almost always seeing swings of 80% or more.
