### PR TITLE
[rust] update http-range-client to ensure tls support

### DIFF
--- a/src/rust/CHANGELOG.md
+++ b/src/rust/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## UNRELEASED
+
+- Ensure reading from tls is supported.
+
 ## [3.27.0] - 2023-08-28
 
 - Fix: Columns of type `short` are now correctly 16 bit, previously they were

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -19,7 +19,7 @@ http = ["http-range-client", "bytes"]
 flatbuffers = "23.5.26"
 byteorder = "1.4.3"
 geozero = { version = "0.11.0", default-features = false }
-http-range-client = { version = "0.6.0", optional = true }
+http-range-client = { version = "0.7.0", optional = true }
 bytes = { version = "1.4.0", optional = true }
 log = "0.4.19"
 fallible-streaming-iterator = "0.1.9"

--- a/src/rust/src/packed_r_tree.rs
+++ b/src/rust/src/packed_r_tree.rs
@@ -164,7 +164,8 @@ async fn read_http_node_items(
     let begin = base + node_index * size_of::<NodeItem>();
     let len = length * size_of::<NodeItem>();
     let bytes = client
-        .get_range(begin, len, min_req_size)
+        .min_req_size(min_req_size)
+        .get_range(begin, len)
         .await
         .map_err(from_http_err)?;
 
@@ -368,7 +369,8 @@ impl PackedRTree {
         let mut pos = index_begin;
         for i in 0..self.num_nodes {
             let bytes = client
-                .get_range(pos, size_of::<NodeItem>(), min_req_size)
+                .min_req_size(min_req_size)
+                .get_range(pos, size_of::<NodeItem>())
                 .await
                 .map_err(from_http_err)?;
             let n = NodeItem::from_bytes(bytes)?;


### PR DESCRIPTION
The previous version of http-range-client didn't enable tls support.

Because features in rust are additive, it's possible that downstream users had enabled tls via some other dependency, but we should make sure it's always supported.
