### PR TITLE
Avoid waiting one second before requesting data

### DIFF
--- a/examples/openlayers/filtered.html
+++ b/examples/openlayers/filtered.html
@@ -77,7 +77,8 @@
                 };
             }
 
-            const results = new ol.source.Vector();
+            // no need for the spatial index since this is only rendering a small extent
+            const results = new ol.source.Vector({useSpatialIndex: false});
             // track the previous results so we can remove them when adding new results
             async function updateResults() {
                 let mapCenter = map.getView().getCenter();
@@ -96,7 +97,7 @@
             }
 
             // if the user is panning around alot, only update once per second max
-            updateResults = _.debounce(updateResults, 1000);
+            updateResults = _.throttle(updateResults, 1000);
   
             const map = new ol.Map({
                 layers: [

--- a/examples/openlayers/large.html
+++ b/examples/openlayers/large.html
@@ -77,7 +77,8 @@
                 };
             }
 
-            const results = new ol.source.Vector();
+            // no need for the spatial index since this is only rendering a small extent
+            const results = new ol.source.Vector({useSpatialIndex: false});
             // track the previous results so we can remove them when adding new results
             async function updateResults() {
                 let mapCenter = map.getView().getCenter();
@@ -97,7 +98,7 @@
             }
 
             // if the user is panning around alot, only update once per second max
-            updateResults = _.debounce(updateResults, 1000);
+            updateResults = _.throttle(updateResults, 1000);
   
             const map = new ol.Map({
                 layers: [


### PR DESCRIPTION
It looks like the OpenLayers filtering examples currently use `_.debounce` when requesting updated data.  The Leaflet and Maplibre examples use `_.throttle` in this same case.  The result is that the OpenLayers example waits 1 second before fetching data while the other examples fetch it immediately (and then avoid fetching more than once per second).

This change updates the OpenLayers example to use `_.throttle` instead of `_.debounce` to match the behavior of the other examples.

In addition, I've set `useSpatialIndex: false` on the vector source for the examples that already filter the data by extent.  In this case, the spatial index is not needed on the source.

Here is the behavior after this change (no delay before fetching data):

![after](https://github.com/flatgeobuf/flatgeobuf/assets/41094/3a76b38a-49a4-4dab-aab5-c6c60cd3c1fc)

And here is the behavior before this change (one second delay before fetching data):

![before](https://github.com/flatgeobuf/flatgeobuf/assets/41094/4144ddfc-8924-4078-b36c-8ba547b053c5)
