### PR TITLE
[rust] refactor: Extract a FeatureIter struct rather than track State param

### DIFF
--- a/src/rust/CHANGELOG.md
+++ b/src/rust/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## UNRELEASED
 
+- Breaking: `select_all` and `select_bbox` now return a FeatureIterator instead of a
+  modified Self type.
 - Ensure reading from tls is supported.
 
 ## [3.27.0] - 2023-08-28

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -94,15 +94,6 @@ pub use header_generated::*;
 pub use http_reader::*;
 pub use properties_reader::*;
 
-// Reader states for ensuring correct read API usage at compile-time
-#[doc(hidden)]
-pub mod reader_state {
-    pub struct Initial;
-    pub struct Open;
-    pub struct FeaturesSelected;
-    pub struct FeaturesSelectedSeek;
-}
-
 // Re-export used traits
 pub use fallible_streaming_iterator::FallibleStreamingIterator;
 

--- a/src/rust/src/packed_r_tree.rs
+++ b/src/rust/src/packed_r_tree.rs
@@ -25,7 +25,9 @@ pub struct NodeItem {
 }
 
 impl NodeItem {
-    #[deprecated(note = "Use NodeItem::bounds instead if you're only using the node item for bounds checking")]
+    #[deprecated(
+        note = "Use NodeItem::bounds instead if you're only using the node item for bounds checking"
+    )]
     pub fn new(min_x: f64, min_y: f64, max_x: f64, max_y: f64) -> NodeItem {
         Self::bounds(min_x, min_y, max_x, max_y)
     }

--- a/src/rust/tests/read.rs
+++ b/src/rust/tests/read.rs
@@ -321,16 +321,13 @@ fn read_etrs89() -> Result<()> {
 
 #[test]
 fn reader_type() -> Result<()> {
-    fn get_opened_reader<R: Read + Seek>(reader: R) -> Result<FgbReader<R, reader_state::Open>> {
-        FgbReader::open(reader)
-    }
     let mut filein = BufReader::new(File::open("../../test/data/countries.fgb")?);
-    let fgb = get_opened_reader(&mut filein)?;
+    let fgb = FgbReader::open(&mut filein)?;
     assert_eq!(fgb.header().features_count(), 179);
 
     fn get_feature_reader<R: Read + Seek>(
         reader: R,
-    ) -> Result<FgbReader<R, reader_state::FeaturesSelectedSeek>> {
+    ) -> Result<FeatureIter<R, reader_trait::Seekable>> {
         FgbReader::open(reader)?.select_all()
     }
     let mut filein = BufReader::new(File::open("../../test/data/countries.fgb")?);
@@ -701,7 +698,7 @@ impl FeatureProcessor for SizeCounter {}
 
 #[test]
 fn test_geozero_size_arg() -> Result<()> {
-    fn get_opened_reader<R: Read + Seek>(reader: R) -> Result<FgbReader<R, reader_state::Open>> {
+    fn get_opened_reader<R: Read + Seek>(reader: R) -> Result<FgbReader<R>> {
         FgbReader::open(reader)
     }
     let mut filein = BufReader::new(File::open("../../test/data/countries.fgb")?);


### PR DESCRIPTION
The State parameter was introduced as a type check to make sure we weren't calling methods at the wrong time - e.g. we can't iterate over a reader before we've selected features.

Instead, we now extract all the state related to iteration into the FeatureIter, achieving the same type checking in a more conventional way (and with a little less code).

Also, the previous mechanism worked only for method calls, but not for field access.  Some of the structs fields were only safe to access when the state had a certain value - like feature_count only gets populated *after* selection. This was already protected by the public method, but now it's also not possible to incorrectly access it via the field.

This might be controversial, since there's no immediate behavioral benefit.

I personally think it stands alone as a small understandability improvement, but TBH my real motivation for this PR is to minimize the diff for some [efficiency experiments](https://github.com/michaelkirk/flatgeobuf/tree/mkirk/streaming-reader) I'd like to start upstreaming. Since the new behavior pertains mostly to the selection (select_all, select_bbox), most of the new behavior ends up living on this newly extracted FeatureIter rather than on the Reader.