### PR TITLE
[go] Only allocate memory when needed

### DIFF
--- a/src/go/index/packed_r_tree.go
+++ b/src/go/index/packed_r_tree.go
@@ -221,8 +221,9 @@ func (r *PackedRTree) generateNodes() {
 }
 
 func (r *PackedRTree) fromData(data []byte, copyData bool) {
-	finalData := make([]byte, r.Size())
+	var finalData []byte
 	if copyData {
+		finalData = make([]byte, r.Size())
 		copy(finalData, data[:r.Size()])
 	} else {
 		finalData = data


### PR DESCRIPTION
- Even when not copying the data for the index (only relevant for memory
   mapped flatgeobuf files, we were allocating the memory to hold the
   copy.
