### PR TITLE
Introduce local Error type rather than using Geozero::GeozeroError

### DIFF
--- a/src/rust/benches/geojson.rs
+++ b/src/rust/benches/geojson.rs
@@ -1,11 +1,12 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use flatgeobuf::*;
-use geozero::error::Result;
 use geozero::geojson::GeoJsonWriter;
 use seek_bufread::BufReader;
 use std::fs::File;
 use std::io::BufWriter;
 use tempfile::tempfile;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 fn fgb_to_geojson() -> Result<()> {
     // Comparison: time ogr2ogr -f GeoJSON /tmp/countries-ogr.json ../../test/data/countries.fgb
@@ -13,7 +14,7 @@ fn fgb_to_geojson() -> Result<()> {
     let mut fgb = FgbReader::open(&mut filein)?.select_all()?;
     let mut fout = BufWriter::new(tempfile()?); // or File::create("/tmp/countries.json")
     let mut json = GeoJsonWriter::new(&mut fout);
-    fgb.process_features(&mut json)
+    Ok(fgb.process_features(&mut json)?)
 }
 
 fn fgb_to_geojson_unchecked() -> Result<()> {
@@ -22,7 +23,7 @@ fn fgb_to_geojson_unchecked() -> Result<()> {
     let mut fgb = unsafe { FgbReader::open_unchecked(&mut filein) }?.select_all()?;
     let mut fout = BufWriter::new(tempfile()?); // or File::create("/tmp/countries.json")
     let mut json = GeoJsonWriter::new(&mut fout);
-    fgb.process_features(&mut json)
+    Ok(fgb.process_features(&mut json)?)
 }
 
 fn fgb_to_geojson_dev_null() -> Result<()> {
@@ -31,7 +32,7 @@ fn fgb_to_geojson_dev_null() -> Result<()> {
     let mut fgb = FgbReader::open(&mut filein)?.select_all()?;
     let mut fout = std::io::sink();
     let mut json = GeoJsonWriter::new(&mut fout);
-    fgb.process_features(&mut json)
+    Ok(fgb.process_features(&mut json)?)
 }
 
 fn fgb_to_geojson_dev_null_unchecked() -> Result<()> {
@@ -40,7 +41,7 @@ fn fgb_to_geojson_dev_null_unchecked() -> Result<()> {
     let mut fgb = unsafe { FgbReader::open_unchecked(&mut filein) }?.select_all()?;
     let mut fout = std::io::sink();
     let mut json = GeoJsonWriter::new(&mut fout);
-    fgb.process_features(&mut json)
+    Ok(fgb.process_features(&mut json)?)
 }
 
 fn fgb_bbox_to_geojson_dev_null() -> Result<()> {
@@ -48,7 +49,7 @@ fn fgb_bbox_to_geojson_dev_null() -> Result<()> {
     let mut fgb = FgbReader::open(&mut filein)?.select_bbox(8.8, 47.2, 9.5, 55.3)?;
     let mut fout = std::io::sink();
     let mut json = GeoJsonWriter::new(&mut fout);
-    fgb.process_features(&mut json)
+    Ok(fgb.process_features(&mut json)?)
 }
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/src/rust/benches/read.rs
+++ b/src/rust/benches/read.rs
@@ -1,9 +1,10 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use flatgeobuf::*;
-use geozero::error::Result;
 use geozero::ProcessorSink;
 use seek_bufread::BufReader;
 use std::fs::File;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 fn read_fgb() -> Result<()> {
     let mut filein = BufReader::new(File::open("../../test/data/countries.fgb")?);

--- a/src/rust/src/error.rs
+++ b/src/rust/src/error.rs
@@ -1,0 +1,45 @@
+use flatbuffers::InvalidFlatbuffer;
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug)]
+pub enum Error {
+    Malformed(&'static str),
+    IO(std::io::Error),
+    InvalidFlatbuffer(InvalidFlatbuffer),
+    #[cfg(feature = "http")]
+    HttpClient(http_range_client::HttpError),
+}
+pub type Result<T> = std::result::Result<T, Error>;
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Malformed(description) => description.fmt(f),
+            Error::IO(io) => io.fmt(f),
+            Error::InvalidFlatbuffer(invalid_flatbuffer) => invalid_flatbuffer.fmt(f),
+            #[cfg(feature = "http")]
+            Error::HttpClient(http_client) => http_client.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<std::io::Error> for Error {
+    fn from(value: std::io::Error) -> Self {
+        Self::IO(value)
+    }
+}
+
+impl From<InvalidFlatbuffer> for Error {
+    fn from(value: InvalidFlatbuffer) -> Self {
+        Error::InvalidFlatbuffer(value)
+    }
+}
+
+#[cfg(feature = "http")]
+impl From<http_range_client::HttpError> for Error {
+    fn from(value: http_range_client::HttpError) -> Self {
+        Error::HttpClient(value)
+    }
+}

--- a/src/rust/src/error.rs
+++ b/src/rust/src/error.rs
@@ -3,7 +3,7 @@ use std::fmt::{Display, Formatter};
 
 #[derive(Debug)]
 pub enum Error {
-    MissingMagicNumber,
+    MissingMagicBytes,
     NoIndex,
     #[cfg(feature = "http")]
     HttpClient(http_range_client::HttpError),
@@ -16,7 +16,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::MissingMagicNumber => "Missing magic bytes. Is this an fgb file?".fmt(f),
+            Error::MissingMagicBytes => "Missing magic bytes. Is this an fgb file?".fmt(f),
             Error::NoIndex => "Index missing".fmt(f),
             #[cfg(feature = "http")]
             Error::HttpClient(http_client) => http_client.fmt(f),

--- a/src/rust/src/error.rs
+++ b/src/rust/src/error.rs
@@ -3,22 +3,26 @@ use std::fmt::{Display, Formatter};
 
 #[derive(Debug)]
 pub enum Error {
-    Malformed(&'static str),
-    IO(std::io::Error),
-    InvalidFlatbuffer(InvalidFlatbuffer),
+    MissingMagicNumber,
+    NoIndex,
     #[cfg(feature = "http")]
     HttpClient(http_range_client::HttpError),
+    IllegalHeaderSize(usize),
+    InvalidFlatbuffer(InvalidFlatbuffer),
+    IO(std::io::Error),
 }
 pub type Result<T> = std::result::Result<T, Error>;
 
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::Malformed(description) => description.fmt(f),
-            Error::IO(io) => io.fmt(f),
-            Error::InvalidFlatbuffer(invalid_flatbuffer) => invalid_flatbuffer.fmt(f),
+            Error::MissingMagicNumber => "Missing magic bytes. Is this an fgb file?".fmt(f),
+            Error::NoIndex => "Index missing".fmt(f),
             #[cfg(feature = "http")]
             Error::HttpClient(http_client) => http_client.fmt(f),
+            Error::IllegalHeaderSize(size) => write!(f, "Illegal header size: {size}"),
+            Error::InvalidFlatbuffer(invalid_flatbuffer) => invalid_flatbuffer.fmt(f),
+            Error::IO(io) => io.fmt(f),
         }
     }
 }

--- a/src/rust/src/file_reader.rs
+++ b/src/rust/src/file_reader.rs
@@ -66,7 +66,7 @@ impl<R: Read> FgbReader<R> {
         let mut magic_buf: [u8; 8] = [0; 8];
         reader.read_exact(&mut magic_buf)?;
         if !check_magic_bytes(&magic_buf) {
-            return Err(Error::MissingMagicNumber);
+            return Err(Error::MissingMagicBytes);
         }
 
         let mut size_buf: [u8; 4] = [0; 4];

--- a/src/rust/src/file_reader.rs
+++ b/src/rust/src/file_reader.rs
@@ -1,12 +1,12 @@
-use crate::{Error, Result};
 use crate::feature_generated::*;
 use crate::header_generated::*;
 use crate::packed_r_tree::{self, PackedRTree};
 use crate::properties_reader::FgbFeature;
 use crate::{check_magic_bytes, HEADER_MAX_BUFFER_SIZE};
+use crate::{Error, Result};
+use fallible_streaming_iterator::FallibleStreamingIterator;
 use std::io::{self, Read, Seek, SeekFrom};
 use std::marker::PhantomData;
-use fallible_streaming_iterator::FallibleStreamingIterator;
 
 /// FlatGeobuf dataset reader
 pub struct FgbReader<R> {
@@ -341,7 +341,10 @@ mod geozero_integration {
         ) -> geozero::error::Result<()> {
             out.dataset_begin(self.fbs.header().name())?;
             let mut cnt = 0;
-            while let Some(feature) = self.next().map_err(|e| GeozeroError::Feature(e.to_string()))? {
+            while let Some(feature) = self
+                .next()
+                .map_err(|e| GeozeroError::Feature(e.to_string()))?
+            {
                 feature.process(out, cnt)?;
                 cnt += 1;
             }
@@ -361,7 +364,10 @@ mod geozero_integration {
         ) -> geozero::error::Result<()> {
             out.dataset_begin(self.fbs.header().name())?;
             let mut cnt = 0;
-            while let Some(feature) = self.next().map_err(|e| GeozeroError::Feature(e.to_string()))? {
+            while let Some(feature) = self
+                .next()
+                .map_err(|e| GeozeroError::Feature(e.to_string()))?
+            {
                 feature.process(out, cnt)?;
                 cnt += 1;
             }

--- a/src/rust/src/file_reader.rs
+++ b/src/rust/src/file_reader.rs
@@ -301,7 +301,7 @@ impl<R: Read + Seek> FallibleStreamingIterator for FeatureIter<R, Seekable> {
     }
 }
 
-mod geozero_integration {
+mod geozero_api {
     use crate::reader_trait::{NotSeekable, Seekable};
     use crate::{FeatureIter, FgbFeature};
     use fallible_streaming_iterator::FallibleStreamingIterator;

--- a/src/rust/src/file_writer.rs
+++ b/src/rust/src/file_writer.rs
@@ -319,7 +319,7 @@ impl<'a> FgbWriter<'a> {
     }
 }
 
-mod geozero_integration {
+mod geozero_api {
     use crate::feature_writer::{prop_type, FeatureWriter};
     use crate::FgbWriter;
     use geozero::error::GeozeroError;

--- a/src/rust/src/file_writer.rs
+++ b/src/rust/src/file_writer.rs
@@ -1,14 +1,10 @@
-use crate::feature_writer::{prop_type, FeatureWriter};
+use crate::error::Result;
+use crate::feature_writer::FeatureWriter;
 use crate::header_generated::{ColumnType, Crs, CrsArgs, GeometryType};
 use crate::packed_r_tree::{calc_extent, hilbert_sort, NodeItem, PackedRTree};
 use crate::{Column, ColumnArgs, Header, HeaderArgs, MAGIC_BYTES};
 use flatbuffers::FlatBufferBuilder;
-use geozero::error::Result;
-use geozero::{
-    ColumnValue, CoordDimensions, FeatureProcessor, GeomProcessor, GeozeroDatasource,
-    GeozeroGeometry, PropertyProcessor,
-};
-use log::info;
+use geozero::CoordDimensions;
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::PathBuf;
@@ -25,7 +21,7 @@ use tempfile::NamedTempFile;
 /// # use std::fs::File;
 /// # use std::io::{BufReader, BufWriter};
 ///
-/// # fn json_to_fgb() -> geozero::error::Result<()> {
+/// # fn json_to_fgb() -> std::result::Result<(), Box<dyn std::error::Error>> {
 /// let mut fgb = FgbWriter::create("countries", GeometryType::MultiPolygon)?;
 /// let mut fin = BufReader::new(File::open("countries.geojson")?);
 /// let mut reader = GeoJsonReader(&mut fin);
@@ -240,48 +236,6 @@ impl<'a> FgbWriter<'a> {
         self.columns.push(Column::create(&mut self.fbb, &col));
     }
 
-    /// Add a new feature.
-    ///
-    /// # Usage example:
-    ///
-    /// ```
-    /// # use flatgeobuf::*;
-    /// use geozero::geojson::GeoJson;
-    /// # let mut fgb = FgbWriter::create("", GeometryType::Point).unwrap();
-    /// let geojson = GeoJson(r#"{"type": "Feature", "properties": {"fid": 42, "name": "New Zealand"}, "geometry": {"type": "Point", "coordinates": [1, 1]}}"#);
-    /// fgb.add_feature(geojson).ok();
-    /// ```
-    pub fn add_feature(&mut self, mut feature: impl GeozeroDatasource) -> Result<()> {
-        feature.process(&mut self.feat_writer)?;
-        self.write_feature()
-    }
-
-    /// Add a new feature from a `GeozeroGeometry`.
-    ///
-    /// # Usage example:
-    ///
-    /// ```
-    /// # use flatgeobuf::*;
-    /// use geozero::geojson::GeoJson;
-    /// use geozero::{ColumnValue, PropertyProcessor};
-    /// # let mut fgb = FgbWriter::create("", GeometryType::Point).unwrap();
-    /// let geom = GeoJson(r#"{"type": "Point", "coordinates": [1, 1]}"#);
-    /// fgb.add_feature_geom(geom, |feat| {
-    ///     feat.property(0, "fid", &ColumnValue::Long(43)).unwrap();
-    ///     feat.property(1, "name", &ColumnValue::String("South Africa"))
-    ///         .unwrap();
-    /// })
-    /// .ok();
-    /// ```
-    pub fn add_feature_geom<F>(&mut self, geom: impl GeozeroGeometry, cfgfn: F) -> Result<()>
-    where
-        F: FnOnce(&mut FeatureWriter),
-    {
-        geom.process_geom(&mut self.feat_writer)?;
-        cfgfn(&mut self.feat_writer);
-        self.write_feature()
-    }
-
     fn write_feature(&mut self) -> Result<()> {
         let mut node = self.feat_writer.bbox.clone();
         // Offset is index of feat_offsets before sorting
@@ -365,129 +319,186 @@ impl<'a> FgbWriter<'a> {
     }
 }
 
-impl FeatureProcessor for FgbWriter<'_> {
-    fn feature_end(&mut self, _idx: u64) -> Result<()> {
-        self.write_feature()
-    }
-}
+mod geozero_integration {
+    use crate::feature_writer::{prop_type, FeatureWriter};
+    use crate::FgbWriter;
+    use geozero::error::GeozeroError;
+    use geozero::{
+        error::Result, ColumnValue, FeatureProcessor, GeomProcessor, GeozeroDatasource,
+        GeozeroGeometry, PropertyProcessor,
+    };
 
-impl PropertyProcessor for FgbWriter<'_> {
-    fn property(&mut self, i: usize, colname: &str, colval: &ColumnValue) -> Result<bool> {
-        if i >= self.columns.len() {
-            if i == self.columns.len() {
-                info!(
+    impl FgbWriter<'_> {
+        /// Add a new feature.
+        ///
+        /// # Usage example:
+        ///
+        /// ```
+        /// # use flatgeobuf::*;
+        /// use geozero::geojson::GeoJson;
+        /// # let mut fgb = FgbWriter::create("", GeometryType::Point).unwrap();
+        /// let geojson = GeoJson(r#"{"type": "Feature", "properties": {"fid": 42, "name": "New Zealand"}, "geometry": {"type": "Point", "coordinates": [1, 1]}}"#);
+        /// fgb.add_feature(geojson).ok();
+        /// ```
+        pub fn add_feature(&mut self, mut feature: impl GeozeroDatasource) -> Result<()> {
+            feature.process(&mut self.feat_writer)?;
+            self.write_feature()
+                .map_err(|e| GeozeroError::Feature(e.to_string()))
+        }
+
+        /// Add a new feature from a `GeozeroGeometry`.
+        ///
+        /// # Usage example:
+        ///
+        /// ```
+        /// # use flatgeobuf::*;
+        /// use geozero::geojson::GeoJson;
+        /// use geozero::{ColumnValue, PropertyProcessor};
+        /// # let mut fgb = FgbWriter::create("", GeometryType::Point).unwrap();
+        /// let geom = GeoJson(r#"{"type": "Point", "coordinates": [1, 1]}"#);
+        /// fgb.add_feature_geom(geom, |feat| {
+        ///     feat.property(0, "fid", &ColumnValue::Long(43)).unwrap();
+        ///     feat.property(1, "name", &ColumnValue::String("South Africa"))
+        ///         .unwrap();
+        /// })
+        /// .ok();
+        /// ```
+        pub fn add_feature_geom<F>(&mut self, geom: impl GeozeroGeometry, cfgfn: F) -> Result<()>
+        where
+            F: FnOnce(&mut FeatureWriter),
+        {
+            geom.process_geom(&mut self.feat_writer)?;
+            cfgfn(&mut self.feat_writer);
+            self.write_feature()
+                .map_err(|e| GeozeroError::Feature(e.to_string()))
+        }
+    }
+
+    impl FeatureProcessor for FgbWriter<'_> {
+        fn feature_end(&mut self, _idx: u64) -> Result<()> {
+            self.write_feature()
+                .map_err(|e| GeozeroError::Feature(e.to_string()))
+        }
+    }
+
+    impl PropertyProcessor for FgbWriter<'_> {
+        fn property(&mut self, i: usize, colname: &str, colval: &ColumnValue) -> Result<bool> {
+            if i >= self.columns.len() {
+                if i == self.columns.len() {
+                    info!(
                     "Undefined property index {i}, column: `{colname}` - adding column declaration"
                 );
-                self.add_column(colname, prop_type(colval), |_, _| {});
-            } else {
-                info!("Undefined property index {i}, column: `{colname}` - skipping");
-                return Ok(false);
+                    self.add_column(colname, prop_type(colval), |_, _| {});
+                } else {
+                    info!("Undefined property index {i}, column: `{colname}` - skipping");
+                    return Ok(false);
+                }
             }
+            // TODO: check name and type against existing declaration
+            self.feat_writer.property(i, colname, colval)
         }
-        // TODO: check name and type against existing declaration
-        self.feat_writer.property(i, colname, colval)
     }
-}
 
-// Delegate GeomProcessor to self.feat_writer
-impl GeomProcessor for FgbWriter<'_> {
-    fn xy(&mut self, x: f64, y: f64, idx: usize) -> Result<()> {
-        self.feat_writer.xy(x, y, idx)
-    }
-    fn coordinate(
-        &mut self,
-        x: f64,
-        y: f64,
-        z: Option<f64>,
-        m: Option<f64>,
-        t: Option<f64>,
-        tm: Option<u64>,
-        idx: usize,
-    ) -> Result<()> {
-        self.feat_writer.coordinate(x, y, z, m, t, tm, idx)
-    }
-    fn point_begin(&mut self, idx: usize) -> Result<()> {
-        self.feat_writer.point_begin(idx)
-    }
-    fn point_end(&mut self, idx: usize) -> Result<()> {
-        self.feat_writer.point_end(idx)
-    }
-    fn multipoint_begin(&mut self, size: usize, idx: usize) -> Result<()> {
-        self.feat_writer.multipoint_begin(size, idx)
-    }
-    fn multipoint_end(&mut self, idx: usize) -> Result<()> {
-        self.feat_writer.multipoint_end(idx)
-    }
-    fn linestring_begin(&mut self, tagged: bool, size: usize, idx: usize) -> Result<()> {
-        self.feat_writer.linestring_begin(tagged, size, idx)
-    }
-    fn linestring_end(&mut self, tagged: bool, idx: usize) -> Result<()> {
-        self.feat_writer.linestring_end(tagged, idx)
-    }
-    fn multilinestring_begin(&mut self, size: usize, idx: usize) -> Result<()> {
-        self.feat_writer.multilinestring_begin(size, idx)
-    }
-    fn multilinestring_end(&mut self, idx: usize) -> Result<()> {
-        self.feat_writer.multilinestring_end(idx)
-    }
-    fn polygon_begin(&mut self, tagged: bool, size: usize, idx: usize) -> Result<()> {
-        self.feat_writer.polygon_begin(tagged, size, idx)
-    }
-    fn polygon_end(&mut self, tagged: bool, idx: usize) -> Result<()> {
-        self.feat_writer.polygon_end(tagged, idx)
-    }
-    fn multipolygon_begin(&mut self, size: usize, idx: usize) -> Result<()> {
-        self.feat_writer.multipolygon_begin(size, idx)
-    }
-    fn multipolygon_end(&mut self, idx: usize) -> Result<()> {
-        self.feat_writer.multipolygon_end(idx)
-    }
-    fn circularstring_begin(&mut self, size: usize, idx: usize) -> Result<()> {
-        self.feat_writer.circularstring_begin(size, idx)
-    }
-    fn circularstring_end(&mut self, idx: usize) -> Result<()> {
-        self.feat_writer.circularstring_end(idx)
-    }
-    fn compoundcurve_begin(&mut self, size: usize, idx: usize) -> Result<()> {
-        self.feat_writer.compoundcurve_begin(size, idx)
-    }
-    fn compoundcurve_end(&mut self, idx: usize) -> Result<()> {
-        self.feat_writer.compoundcurve_end(idx)
-    }
-    fn curvepolygon_begin(&mut self, size: usize, idx: usize) -> Result<()> {
-        self.feat_writer.curvepolygon_begin(size, idx)
-    }
-    fn curvepolygon_end(&mut self, idx: usize) -> Result<()> {
-        self.feat_writer.curvepolygon_end(idx)
-    }
-    fn multicurve_begin(&mut self, size: usize, idx: usize) -> Result<()> {
-        self.feat_writer.multicurve_begin(size, idx)
-    }
-    fn multicurve_end(&mut self, idx: usize) -> Result<()> {
-        self.feat_writer.multicurve_end(idx)
-    }
-    fn multisurface_begin(&mut self, size: usize, idx: usize) -> Result<()> {
-        self.feat_writer.multisurface_begin(size, idx)
-    }
-    fn multisurface_end(&mut self, idx: usize) -> Result<()> {
-        self.feat_writer.multisurface_end(idx)
-    }
-    fn triangle_begin(&mut self, tagged: bool, size: usize, idx: usize) -> Result<()> {
-        self.feat_writer.triangle_begin(tagged, size, idx)
-    }
-    fn triangle_end(&mut self, tagged: bool, idx: usize) -> Result<()> {
-        self.feat_writer.triangle_end(tagged, idx)
-    }
-    fn polyhedralsurface_begin(&mut self, size: usize, idx: usize) -> Result<()> {
-        self.feat_writer.polyhedralsurface_begin(size, idx)
-    }
-    fn polyhedralsurface_end(&mut self, idx: usize) -> Result<()> {
-        self.feat_writer.polyhedralsurface_end(idx)
-    }
-    fn tin_begin(&mut self, size: usize, idx: usize) -> Result<()> {
-        self.feat_writer.tin_begin(size, idx)
-    }
-    fn tin_end(&mut self, idx: usize) -> Result<()> {
-        self.feat_writer.tin_end(idx)
+    // Delegate GeomProcessor to self.feat_writer
+    impl GeomProcessor for FgbWriter<'_> {
+        fn xy(&mut self, x: f64, y: f64, idx: usize) -> Result<()> {
+            self.feat_writer.xy(x, y, idx)
+        }
+        fn coordinate(
+            &mut self,
+            x: f64,
+            y: f64,
+            z: Option<f64>,
+            m: Option<f64>,
+            t: Option<f64>,
+            tm: Option<u64>,
+            idx: usize,
+        ) -> Result<()> {
+            self.feat_writer.coordinate(x, y, z, m, t, tm, idx)
+        }
+        fn point_begin(&mut self, idx: usize) -> Result<()> {
+            self.feat_writer.point_begin(idx)
+        }
+        fn point_end(&mut self, idx: usize) -> Result<()> {
+            self.feat_writer.point_end(idx)
+        }
+        fn multipoint_begin(&mut self, size: usize, idx: usize) -> Result<()> {
+            self.feat_writer.multipoint_begin(size, idx)
+        }
+        fn multipoint_end(&mut self, idx: usize) -> Result<()> {
+            self.feat_writer.multipoint_end(idx)
+        }
+        fn linestring_begin(&mut self, tagged: bool, size: usize, idx: usize) -> Result<()> {
+            self.feat_writer.linestring_begin(tagged, size, idx)
+        }
+        fn linestring_end(&mut self, tagged: bool, idx: usize) -> Result<()> {
+            self.feat_writer.linestring_end(tagged, idx)
+        }
+        fn multilinestring_begin(&mut self, size: usize, idx: usize) -> Result<()> {
+            self.feat_writer.multilinestring_begin(size, idx)
+        }
+        fn multilinestring_end(&mut self, idx: usize) -> Result<()> {
+            self.feat_writer.multilinestring_end(idx)
+        }
+        fn polygon_begin(&mut self, tagged: bool, size: usize, idx: usize) -> Result<()> {
+            self.feat_writer.polygon_begin(tagged, size, idx)
+        }
+        fn polygon_end(&mut self, tagged: bool, idx: usize) -> Result<()> {
+            self.feat_writer.polygon_end(tagged, idx)
+        }
+        fn multipolygon_begin(&mut self, size: usize, idx: usize) -> Result<()> {
+            self.feat_writer.multipolygon_begin(size, idx)
+        }
+        fn multipolygon_end(&mut self, idx: usize) -> Result<()> {
+            self.feat_writer.multipolygon_end(idx)
+        }
+        fn circularstring_begin(&mut self, size: usize, idx: usize) -> Result<()> {
+            self.feat_writer.circularstring_begin(size, idx)
+        }
+        fn circularstring_end(&mut self, idx: usize) -> Result<()> {
+            self.feat_writer.circularstring_end(idx)
+        }
+        fn compoundcurve_begin(&mut self, size: usize, idx: usize) -> Result<()> {
+            self.feat_writer.compoundcurve_begin(size, idx)
+        }
+        fn compoundcurve_end(&mut self, idx: usize) -> Result<()> {
+            self.feat_writer.compoundcurve_end(idx)
+        }
+        fn curvepolygon_begin(&mut self, size: usize, idx: usize) -> Result<()> {
+            self.feat_writer.curvepolygon_begin(size, idx)
+        }
+        fn curvepolygon_end(&mut self, idx: usize) -> Result<()> {
+            self.feat_writer.curvepolygon_end(idx)
+        }
+        fn multicurve_begin(&mut self, size: usize, idx: usize) -> Result<()> {
+            self.feat_writer.multicurve_begin(size, idx)
+        }
+        fn multicurve_end(&mut self, idx: usize) -> Result<()> {
+            self.feat_writer.multicurve_end(idx)
+        }
+        fn multisurface_begin(&mut self, size: usize, idx: usize) -> Result<()> {
+            self.feat_writer.multisurface_begin(size, idx)
+        }
+        fn multisurface_end(&mut self, idx: usize) -> Result<()> {
+            self.feat_writer.multisurface_end(idx)
+        }
+        fn triangle_begin(&mut self, tagged: bool, size: usize, idx: usize) -> Result<()> {
+            self.feat_writer.triangle_begin(tagged, size, idx)
+        }
+        fn triangle_end(&mut self, tagged: bool, idx: usize) -> Result<()> {
+            self.feat_writer.triangle_end(tagged, idx)
+        }
+        fn polyhedralsurface_begin(&mut self, size: usize, idx: usize) -> Result<()> {
+            self.feat_writer.polyhedralsurface_begin(size, idx)
+        }
+        fn polyhedralsurface_end(&mut self, idx: usize) -> Result<()> {
+            self.feat_writer.polyhedralsurface_end(idx)
+        }
+        fn tin_begin(&mut self, size: usize, idx: usize) -> Result<()> {
+            self.feat_writer.tin_begin(size, idx)
+        }
+        fn tin_end(&mut self, idx: usize) -> Result<()> {
+            self.feat_writer.tin_end(idx)
+        }
     }
 }

--- a/src/rust/src/http_reader.rs
+++ b/src/rust/src/http_reader.rs
@@ -65,7 +65,7 @@ impl HttpFgbReader {
 
         let bytes = client.get_range(0, 8).await?;
         if !check_magic_bytes(bytes) {
-            return Err(Error::MissingMagicNumber);
+            return Err(Error::MissingMagicBytes);
         }
         let mut bytes = BytesMut::from(client.get_range(8, 4).await?);
         let header_size = LittleEndian::read_u32(&bytes) as usize;

--- a/src/rust/src/http_reader.rs
+++ b/src/rust/src/http_reader.rs
@@ -1,9 +1,9 @@
-use crate::{Error, Result};
 use crate::feature_generated::*;
 use crate::header_generated::*;
 use crate::packed_r_tree::{self, NodeItem, PackedRTree};
 use crate::properties_reader::FgbFeature;
 use crate::{check_magic_bytes, HEADER_MAX_BUFFER_SIZE};
+use crate::{Error, Result};
 use byteorder::{ByteOrder, LittleEndian};
 use bytes::{BufMut, BytesMut};
 use http_range_client::BufferedHttpRangeClient;

--- a/src/rust/src/http_reader.rs
+++ b/src/rust/src/http_reader.rs
@@ -201,7 +201,7 @@ impl AsyncFeatureIter {
     }
 }
 
-mod geozero_integration {
+mod geozero_api {
     use crate::AsyncFeatureIter;
     use geozero::{error::Result, FeatureAccess, FeatureProcessor};
 

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -12,7 +12,7 @@
 //! # use std::fs::File;
 //! # use std::io::BufReader;
 //!
-//! # fn read_fbg() -> geozero::error::Result<()> {
+//! # fn read_fgb() -> std::result::Result<(), Box<dyn std::error::Error>> {
 //! let mut filein = BufReader::new(File::open("countries.fgb")?);
 //! let mut fgb = FgbReader::open(&mut filein)?.select_all()?;
 //! while let Some(feature) = fgb.next()? {
@@ -30,7 +30,7 @@
 //! use geozero::ToWkt;
 //!
 //! # #[cfg(feature = "http")]
-//! # async fn read_fbg() -> geozero::error::Result<()> {
+//! # async fn read_fbg() -> std::result::Result<(), Box<dyn std::error::Error>> {
 //! let mut fgb = HttpFgbReader::open("https://flatgeobuf.org/test/data/countries.fgb")
 //!     .await?
 //!     .select_bbox(8.8, 47.2, 9.5, 55.3)
@@ -53,7 +53,7 @@
 //! # use std::fs::File;
 //! # use std::io::{BufReader, BufWriter};
 //!
-//! # fn json_to_fgb() -> geozero::error::Result<()> {
+//! # fn json_to_fgb() -> std::result::Result<(), Box<dyn std::error::Error>> {
 //! let mut fgb = FgbWriter::create("countries", GeometryType::MultiPolygon)?;
 //! let mut fin = BufReader::new(File::open("countries.geojson")?);
 //! let mut reader = GeoJsonReader(&mut fin);
@@ -70,6 +70,7 @@
 #[macro_use]
 extern crate log;
 
+mod error;
 #[allow(unused_imports, non_snake_case, clippy::all)]
 #[rustfmt::skip]
 mod feature_generated;
@@ -85,6 +86,7 @@ mod http_reader;
 pub mod packed_r_tree;
 mod properties_reader;
 
+pub use error::{Error, Result};
 pub use feature_generated::*;
 pub use file_reader::*;
 pub use file_writer::*;

--- a/src/rust/src/packed_r_tree.rs
+++ b/src/rust/src/packed_r_tree.rs
@@ -1,10 +1,9 @@
 //! Create and read a [packed Hilbert R-Tree](https://en.wikipedia.org/wiki/Hilbert_R-tree#Packed_Hilbert_R-trees)
 //! to enable fast bounding box spatial filtering.
 
-#[cfg(feature = "http")]
-use crate::http_reader::from_http_err;
+use crate::{Error, Result};
+
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use geozero::error::{GeozeroError, Result};
 #[cfg(feature = "http")]
 use http_range_client::BufferedHttpRangeClient;
 use std::cmp::{max, min};
@@ -173,8 +172,7 @@ async fn read_http_node_items(
     let bytes = client
         .min_req_size(min_req_size)
         .get_range(begin, len)
-        .await
-        .map_err(from_http_err)?;
+        .await?;
 
     let mut node_items = Vec::with_capacity(length);
     for i in 0..length {
@@ -297,7 +295,7 @@ impl PackedRTree {
         self.num_nodes = self
             .level_bounds
             .first()
-            .ok_or(GeozeroError::GeometryIndex)?
+            .ok_or(Error::Malformed("Unable to determine bounds for index"))?
             .1;
         self.node_items = vec![NodeItem::create(0); self.num_nodes]; // Quite slow!
         Ok(())
@@ -378,8 +376,7 @@ impl PackedRTree {
             let bytes = client
                 .min_req_size(min_req_size)
                 .get_range(pos, size_of::<NodeItem>())
-                .await
-                .map_err(from_http_err)?;
+                .await?;
             let n = NodeItem::from_bytes(bytes)?;
             self.extent.expand(&n);
             self.node_items[i] = n;
@@ -408,7 +405,10 @@ impl PackedRTree {
     pub fn from_buf(data: impl Read, num_items: usize, node_size: u16) -> Result<PackedRTree> {
         let node_size = min(max(node_size, 2u16), 65535u16);
         let level_bounds = PackedRTree::generate_level_bounds(num_items, node_size);
-        let num_nodes = level_bounds.first().ok_or(GeozeroError::GeometryIndex)?.1;
+        let num_nodes = level_bounds
+            .first()
+            .ok_or(Error::Malformed("Unable to determine bounds for index"))?
+            .1;
         let mut tree = PackedRTree {
             extent: NodeItem::create(0),
             node_items: Vec::with_capacity(num_nodes),
@@ -451,7 +451,7 @@ impl PackedRTree {
         let leaf_nodes_offset = self
             .level_bounds
             .first()
-            .ok_or(GeozeroError::GeometryIndex)?
+            .ok_or(Error::Malformed("Unable to determine bounds for index"))?
             .0;
         let bounds = NodeItem::bounds(min_x, min_y, max_x, max_y);
         let mut results = Vec::new();
@@ -496,8 +496,9 @@ impl PackedRTree {
     ) -> Result<Vec<SearchResultItem>> {
         let bounds = NodeItem::bounds(min_x, min_y, max_x, max_y);
         let level_bounds = PackedRTree::generate_level_bounds(num_items, node_size);
-        let leaf_nodes_offset = level_bounds.first().ok_or(GeozeroError::GeometryIndex)?.0;
-        let num_nodes = level_bounds.first().ok_or(GeozeroError::GeometryIndex)?.1;
+        let (leaf_nodes_offset, num_nodes) = level_bounds
+            .first()
+            .ok_or(Error::Malformed("Unable to determine bounds for index"))?;
 
         // current position must be start of index
         let index_base = data.stream_position()?;
@@ -557,7 +558,10 @@ impl PackedRTree {
     ) -> Result<Vec<SearchResultItem>> {
         let bounds = NodeItem::bounds(min_x, min_y, max_x, max_y);
         let level_bounds = PackedRTree::generate_level_bounds(num_items, node_size);
-        let leaf_nodes_offset = level_bounds.first().ok_or(GeozeroError::GeometryIndex)?.0;
+        let leaf_nodes_offset = level_bounds
+            .first()
+            .ok_or(Error::Malformed("Unable to determine bounds for index"))?
+            .0;
         debug!("http_stream_search - index_begin: {index_begin}, num_items: {num_items}, node_size: {node_size}, level_bounds: {level_bounds:?}, GPS bounds:[({min_x}, {min_y}), ({max_x},{max_y})]");
 
         #[derive(Debug, PartialEq, Eq)]
@@ -689,7 +693,10 @@ mod inspect {
     use geozero::{ColumnValue, FeatureProcessor};
 
     impl PackedRTree {
-        pub fn process_index<P: FeatureProcessor>(&self, processor: &mut P) -> Result<()> {
+        pub fn process_index<P: FeatureProcessor>(
+            &self,
+            processor: &mut P,
+        ) -> geozero::error::Result<()> {
             processor.dataset_begin(Some("PackedRTree"))?;
             let mut fid = 0;
             for (levelno, level) in self.level_bounds.iter().rev().enumerate() {
@@ -886,6 +893,7 @@ fn tree_processing() -> Result<()> {
     }
     let tree = PackedRTree::build(&nodes, &extent, PackedRTree::DEFAULT_NODE_SIZE)?;
     let mut fout = BufWriter::new(tempfile()?);
-    tree.process_index(&mut GeoJsonWriter::new(&mut fout))?;
+    tree.process_index(&mut GeoJsonWriter::new(&mut fout))
+        .unwrap();
     Ok(())
 }

--- a/src/rust/src/packed_r_tree.rs
+++ b/src/rust/src/packed_r_tree.rs
@@ -1,7 +1,7 @@
 //! Create and read a [packed Hilbert R-Tree](https://en.wikipedia.org/wiki/Hilbert_R-tree#Packed_Hilbert_R-trees)
 //! to enable fast bounding box spatial filtering.
 
-use crate::{Error, Result};
+use crate::Result;
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 #[cfg(feature = "http")]
@@ -295,7 +295,7 @@ impl PackedRTree {
         self.num_nodes = self
             .level_bounds
             .first()
-            .ok_or(Error::Malformed("Unable to determine bounds for index"))?
+            .expect("RTree has at least one level when node_size >= 2 and num_items > 0")
             .1;
         self.node_items = vec![NodeItem::create(0); self.num_nodes]; // Quite slow!
         Ok(())
@@ -407,7 +407,7 @@ impl PackedRTree {
         let level_bounds = PackedRTree::generate_level_bounds(num_items, node_size);
         let num_nodes = level_bounds
             .first()
-            .ok_or(Error::Malformed("Unable to determine bounds for index"))?
+            .expect("RTree has at least one level when node_size >= 2 and num_items > 0")
             .1;
         let mut tree = PackedRTree {
             extent: NodeItem::create(0),
@@ -451,7 +451,7 @@ impl PackedRTree {
         let leaf_nodes_offset = self
             .level_bounds
             .first()
-            .ok_or(Error::Malformed("Unable to determine bounds for index"))?
+            .expect("RTree has at least one level when node_size >= 2 and num_items > 0")
             .0;
         let bounds = NodeItem::bounds(min_x, min_y, max_x, max_y);
         let mut results = Vec::new();
@@ -498,7 +498,7 @@ impl PackedRTree {
         let level_bounds = PackedRTree::generate_level_bounds(num_items, node_size);
         let (leaf_nodes_offset, num_nodes) = level_bounds
             .first()
-            .ok_or(Error::Malformed("Unable to determine bounds for index"))?;
+            .expect("RTree has at least one level when node_size >= 2 and num_items > 0");
 
         // current position must be start of index
         let index_base = data.stream_position()?;
@@ -560,7 +560,7 @@ impl PackedRTree {
         let level_bounds = PackedRTree::generate_level_bounds(num_items, node_size);
         let leaf_nodes_offset = level_bounds
             .first()
-            .ok_or(Error::Malformed("Unable to determine bounds for index"))?
+            .expect("RTree has at least one level when node_size >= 2 and num_items > 0")
             .0;
         debug!("http_stream_search - index_begin: {index_begin}, num_items: {num_items}, node_size: {node_size}, level_bounds: {level_bounds:?}, GPS bounds:[({min_x}, {min_y}), ({max_x},{max_y})]");
 

--- a/src/rust/tests/geojson.rs
+++ b/src/rust/tests/geojson.rs
@@ -1,8 +1,9 @@
 use flatgeobuf::*;
-use geozero::error::Result;
 use geozero::geojson::GeoJsonWriter;
 use std::fs::File;
 use std::io::BufReader;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 #[test]
 fn fgb_to_geojson() -> Result<()> {

--- a/src/rust/tests/http_read.rs
+++ b/src/rust/tests/http_read.rs
@@ -2,7 +2,8 @@
 mod http {
 
     use flatgeobuf::*;
-    use geozero::error::Result;
+
+    type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
     #[tokio::test]
     async fn http_read() -> Result<()> {
@@ -45,10 +46,7 @@ mod http {
             .await?
             .select_bbox(8.8, 47.2, 9.5, 55.3)
             .await;
-        assert_eq!(
-            fgb.err().unwrap().to_string(),
-            "processing geometry `Index missing`"
-        );
+        assert_eq!(fgb.err().unwrap().to_string(), "Index missing");
         Ok(())
     }
 

--- a/src/rust/tests/read.rs
+++ b/src/rust/tests/read.rs
@@ -314,13 +314,8 @@ fn reader_type() -> Result<()> {
     let fgb = FgbReader::open(&mut filein)?;
     assert_eq!(fgb.header().features_count(), 179);
 
-    fn get_feature_reader<R: Read + Seek>(
-        reader: R,
-    ) -> Result<FeatureIter<R, reader_trait::Seekable>> {
-        Ok(FgbReader::open(reader)?.select_all()?)
-    }
-    let mut filein = BufReader::new(File::open("../../test/data/countries.fgb")?);
-    let fgb = get_feature_reader(&mut filein)?;
+    let filein = BufReader::new(File::open("../../test/data/countries.fgb")?);
+    let fgb = FgbReader::open(filein)?.select_all()?;
     assert_eq!(fgb.features_count(), Some(179));
 
     Ok(())

--- a/src/rust/tests/read.rs
+++ b/src/rust/tests/read.rs
@@ -1,12 +1,13 @@
 use flatgeobuf::packed_r_tree::*;
 use flatgeobuf::*;
-use geozero::error::Result;
 use geozero::wkt::WktWriter;
 use geozero::{
     ColumnValue, CoordDimensions, FeatureProcessor, GeomProcessor, PropertyProcessor, ToWkt,
 };
 use std::fs::File;
 use std::io::{BufReader, Read, Seek, SeekFrom};
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 #[test]
 fn reader_headers_checked() {
@@ -145,10 +146,7 @@ fn read_empty_dataset() -> Result<()> {
 
     let mut filein = BufReader::new(File::open("../../test/data/empty.fgb")?);
     let fgb = FgbReader::open(&mut filein)?.select_bbox(8.8, 47.2, 9.5, 55.3);
-    assert_eq!(
-        fgb.err().unwrap().to_string(),
-        "processing geometry `Index missing`"
-    );
+    assert_eq!(fgb.err().unwrap().to_string(), "Index missing");
 
     let mut filein = BufReader::new(File::open("../../test/data/empty.fgb")?);
     let mut fgb = FgbReader::open(&mut filein)?.select_all_seq()?;
@@ -157,10 +155,7 @@ fn read_empty_dataset() -> Result<()> {
 
     let mut filein = BufReader::new(File::open("../../test/data/empty.fgb")?);
     let fgb = FgbReader::open(&mut filein)?.select_bbox_seq(8.8, 47.2, 9.5, 55.3);
-    assert_eq!(
-        fgb.err().unwrap().to_string(),
-        "processing geometry `Index missing`"
-    );
+    assert_eq!(fgb.err().unwrap().to_string(), "Index missing");
 
     Ok(())
 }
@@ -181,10 +176,7 @@ fn read_unknown_feature_count() -> Result<()> {
 
     let mut filein = BufReader::new(File::open("../../test/data/unknown_feature_count.fgb")?);
     let fgb = FgbReader::open(&mut filein)?.select_bbox(8.8, 47.2, 9.5, 55.3);
-    assert_eq!(
-        fgb.err().unwrap().to_string(),
-        "processing geometry `Index missing`"
-    );
+    assert_eq!(fgb.err().unwrap().to_string(), "Index missing");
     Ok(())
 }
 
@@ -232,17 +224,14 @@ fn read_unknown_feature_count_seq() -> Result<()> {
 
     let mut filein = BufReader::new(File::open("../../test/data/unknown_feature_count.fgb")?);
     let fgb = FgbReader::open(&mut filein)?.select_bbox_seq(8.8, 47.2, 9.5, 55.3);
-    assert_eq!(
-        fgb.err().unwrap().to_string(),
-        "processing geometry `Index missing`"
-    );
+    assert_eq!(fgb.err().unwrap().to_string(), "Index missing");
     Ok(())
 }
 
 struct VertexCounter(u64);
 
 impl GeomProcessor for VertexCounter {
-    fn xy(&mut self, _x: f64, _y: f64, _idx: usize) -> Result<()> {
+    fn xy(&mut self, _x: f64, _y: f64, _idx: usize) -> geozero::error::Result<()> {
         self.0 += 1;
         Ok(())
     }
@@ -328,7 +317,7 @@ fn reader_type() -> Result<()> {
     fn get_feature_reader<R: Read + Seek>(
         reader: R,
     ) -> Result<FeatureIter<R, reader_trait::Seekable>> {
-        FgbReader::open(reader)?.select_all()
+        Ok(FgbReader::open(reader)?.select_all()?)
     }
     let mut filein = BufReader::new(File::open("../../test/data/countries.fgb")?);
     let fgb = get_feature_reader(&mut filein)?;
@@ -342,7 +331,7 @@ fn magic_byte() -> Result<()> {
     let mut filein = BufReader::new(File::open("../../test/data/states.geojson")?);
     assert_eq!(
         FgbReader::open(&mut filein).err().unwrap().to_string(),
-        "geometry format"
+        "Missing magic bytes"
     );
 
     Ok(())
@@ -558,7 +547,7 @@ impl GeomProcessor for MaxFinder {
         _t: Option<f64>,
         _tm: Option<u64>,
         _idx: usize,
-    ) -> Result<()> {
+    ) -> geozero::error::Result<()> {
         if let Some(z) = z {
             if z > self.0 {
                 self.0 = z
@@ -609,7 +598,7 @@ struct PropChecker<'a> {
 }
 
 impl PropertyProcessor for PropChecker<'_> {
-    fn property(&mut self, i: usize, _name: &str, v: &ColumnValue) -> Result<bool> {
+    fn property(&mut self, i: usize, _name: &str, v: &ColumnValue) -> geozero::error::Result<bool> {
         assert_eq!(v, &self.expected[i]);
         Ok(false)
     }
@@ -672,18 +661,23 @@ impl SizeCounter {
 }
 
 impl GeomProcessor for SizeCounter {
-    fn linestring_begin(&mut self, _tagged: bool, size: usize, _idx: usize) -> Result<()> {
+    fn linestring_begin(
+        &mut self,
+        _tagged: bool,
+        size: usize,
+        _idx: usize,
+    ) -> geozero::error::Result<()> {
         self.expected_xy = size as u64;
         self.actual_xy = 0;
         Ok(())
     }
 
-    fn xy(&mut self, _x: f64, _y: f64, _idx: usize) -> Result<()> {
+    fn xy(&mut self, _x: f64, _y: f64, _idx: usize) -> geozero::error::Result<()> {
         self.actual_xy += 1;
         Ok(())
     }
 
-    fn linestring_end(&mut self, _tagged: bool, _idx: usize) -> Result<()> {
+    fn linestring_end(&mut self, _tagged: bool, _idx: usize) -> geozero::error::Result<()> {
         assert_eq!(
             self.expected_xy, self.actual_xy,
             "Expected xy() to be called {} times, but was called {} times",
@@ -698,11 +692,8 @@ impl FeatureProcessor for SizeCounter {}
 
 #[test]
 fn test_geozero_size_arg() -> Result<()> {
-    fn get_opened_reader<R: Read + Seek>(reader: R) -> Result<FgbReader<R>> {
-        FgbReader::open(reader)
-    }
     let mut filein = BufReader::new(File::open("../../test/data/countries.fgb")?);
-    let fgb = get_opened_reader(&mut filein)?;
+    let fgb = FgbReader::open(&mut filein)?;
 
     let mut size_counter = SizeCounter::new();
     fgb.select_all()

--- a/src/rust/tests/read.rs
+++ b/src/rust/tests/read.rs
@@ -326,7 +326,7 @@ fn magic_byte() -> Result<()> {
     let mut filein = BufReader::new(File::open("../../test/data/states.geojson")?);
     assert_eq!(
         FgbReader::open(&mut filein).err().unwrap().to_string(),
-        "Missing magic bytes"
+        "Missing magic bytes. Is this an fgb file?"
     );
 
     Ok(())

--- a/src/rust/tests/svg.rs
+++ b/src/rust/tests/svg.rs
@@ -1,9 +1,9 @@
 use flatgeobuf::*;
-use geozero::error::Result;
 use geozero::svg::SvgWriter;
 use geozero::wkt::WktWriter;
 use std::fs::File;
 use std::io::{BufReader, Write};
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 fn invert_y(header: &Header) -> bool {
     if let Some(crs) = header.crs() {
@@ -46,7 +46,7 @@ impl GeomToSvg for Geometry<'_> {
         invert_y: bool,
     ) -> Result<()> {
         let mut svg = SvgWriter::new(out, invert_y);
-        self.process(&mut svg, geometry_type)
+        Ok(self.process(&mut svg, geometry_type)?)
     }
 }
 
@@ -69,7 +69,7 @@ impl FeatureToSvg for Feature<'_> {
     ) -> Result<()> {
         let mut svg = SvgWriter::new(out, invert_y);
         let geometry = self.geometry().unwrap();
-        geometry.process(&mut svg, geometry_type)
+        Ok(geometry.process(&mut svg, geometry_type)?)
     }
 }
 

--- a/src/rust/tests/write.rs
+++ b/src/rust/tests/write.rs
@@ -1,12 +1,13 @@
 use crate::FgbWriter;
 use flatgeobuf::*;
 use geo_types::{line_string, LineString};
-use geozero::error::Result;
 use geozero::geojson::{GeoJson, GeoJsonReader};
 use geozero::{ColumnValue, GeozeroDatasource, PropertyProcessor};
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Write};
 use tempfile::{tempfile, NamedTempFile};
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 #[test]
 fn write_file() -> std::io::Result<()> {

--- a/src/rust/tests/write.rs
+++ b/src/rust/tests/write.rs
@@ -204,7 +204,7 @@ fn column_size() -> Result<()> {
     assert_eq!(max_ubyte, u8::MAX);
 
     let max_bool: bool = feature.property_n(2).expect("valid bool");
-    assert_eq!(max_bool, true);
+    assert!(max_bool);
 
     let max_short: i16 = feature.property_n(3).expect("valid short");
     assert_eq!(max_short, i16::MAX);


### PR DESCRIPTION
## Motivation


Currently we have a circular dependency between the geozero and flatgeobuf crates. Some related discussion in
https://github.com/flatgeobuf/flatgeobuf/issues/283

This starts to detangle us from geozero by introducing our own error type and using that for non-geozero code. It also allows us to have an error enum more suited for our use cases.

## What changed

1. Introduce a new `flatgeobuf::Error` type and use it for code that doesn't depend on Geozero.
2. Relocate code that depends on Geozero into separate `geozero_integration` modules. This code still returns GeozeroError.
3. For tests and benchs, which might return either `flatgeobuf::Error` or `geozero::GeozeroError` and mapping between them is verbose, use `Box<dyn std::error::Error>`. Alternatively, I'd also be OK with using `unwrap` everywhere in test code, but I was trying not to rock the boat too much.