### PR TITLE
[go] Fix invalid array length

### DIFF
--- a/src/go/index/packed_r_tree.go
+++ b/src/go/index/packed_r_tree.go
@@ -137,7 +137,7 @@ func (r *PackedRTree) Size() uint64 {
 // with NewPackedRTreeFromData.
 func (r *PackedRTree) Write(w io.Writer) (int, error) {
 	// Fast conversion from  []NodeItems to []byte.
-	data := (*(*[1 << 31]byte)(unsafe.Pointer(
+	data := (*(*[1 << 31 - 1]byte)(unsafe.Pointer(
 		&r.nodeItems[0])))[:r.Size()]
 
 	return w.Write(data)
@@ -230,7 +230,7 @@ func (r *PackedRTree) fromData(data []byte, copyData bool) {
 	}
 
 	// Fast conversion from []byte to []NodeItem.
-	r.nodeItems = (*[1 << 31]NodeItem)(unsafe.Pointer(&finalData[0]))[:r.numNodes]
+	r.nodeItems = (*[1 << 31 - 1]NodeItem)(unsafe.Pointer(&finalData[0]))[:r.numNodes]
 
 	for i := 0; i < int(r.numNodes); i++ {
 		r.extent.Expand(r.nodeItems[i])


### PR DESCRIPTION
We are getting the following errors during compilation when targetting a 32-bit system (e.g., tinygo build -target=wasi ...)

```
../src/go/index/packed_r_tree.go:144:15: invalid array length 1 << 31 (untyped int constant 2147483648)
../src/go/index/packed_r_tree.go:237:19: invalid array length 1 << 31 (untyped int constant 2147483648)
```

This commit fixes the issues above.

This [SO answer](https://stackoverflow.com/a/28552459) is the only reference I can find regarding the maximum array size.

> The size 1<<31 - 1 is the largest possible size any slice in Go can have.

I also confirm that with this change, I can compile successfully. 