### PR TITLE
[rust] Batch nearby HTTP requests for bbox features

### DIFF
--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -35,7 +35,7 @@ tokio = { version = "1.30.0", features = ["rt-multi-thread"] }
 # One test needs SSL support; just use the default system bindings for that.
 reqwest = { version = "0.11.18", default-features = true }
 geo-types = "0.7.11"
-yocalhost = "0.1.0"
+yocalhost = "0.3.0"
 
 [[bench]]
 name = "read"

--- a/src/rust/src/http_reader.rs
+++ b/src/rust/src/http_reader.rs
@@ -251,7 +251,6 @@ impl SelectBbox {
         let mut next_buffer = None;
         while next_buffer.is_none() {
             let Some(feature_batch) = self.feature_batches.last_mut() else {
-                debug!("no batches remain");
                 break;
             };
             let Some(buffer) = feature_batch.next_buffer(client).await? else {
@@ -308,7 +307,7 @@ impl FeatureBatch {
                 }
                 latest_batch.push(search_result_item.range)
             } else {
-                debug!("creating a new request for batch rather than wasting {wasted_bytes} bytes");
+                trace!("creating a new request for batch rather than wasting {wasted_bytes} bytes");
                 batched_ranges.push(vec![search_result_item.range]);
             }
         }

--- a/src/rust/src/packed_r_tree.rs
+++ b/src/rust/src/packed_r_tree.rs
@@ -188,7 +188,7 @@ async fn read_http_node_items(
 pub struct SearchResultItem {
     /// Byte offset in feature data section
     pub offset: usize,
-    /// Feature number (REVIEW: why do we need this?)
+    /// Feature number
     pub index: usize,
 }
 
@@ -619,13 +619,11 @@ impl PackedRTree {
                         let end = feature_begin + next_node_item.offset as usize;
                         results.push(HttpSearchResultItem {
                             range: HttpRange::Range(start..end),
-                            index: node_id,
                         });
                     } else {
                         debug_assert_eq!(node_pos, num_items);
                         results.push(HttpSearchResultItem {
                             range: HttpRange::RangeFrom(start..),
-                            index: node_id,
                         });
                     }
                     continue;
@@ -757,8 +755,6 @@ pub(crate) mod http {
     pub struct HttpSearchResultItem {
         /// Byte offset in feature data section
         pub range: HttpRange,
-        /// Feature number (REVIEW: why do we need this?)
-        pub index: usize,
     }
 }
 #[cfg(feature = "http")]

--- a/src/rust/src/packed_r_tree.rs
+++ b/src/rust/src/packed_r_tree.rs
@@ -623,7 +623,6 @@ impl PackedRTree {
                         });
                     } else {
                         debug_assert_eq!(node_pos, num_items);
-                        debug!("No next length (final item)");
                         results.push(HttpSearchResultItem {
                             range: HttpRange::RangeFrom(start..),
                             index: node_id,

--- a/src/rust/src/packed_r_tree.rs
+++ b/src/rust/src/packed_r_tree.rs
@@ -162,20 +162,20 @@ fn read_node_items<R: Read + Seek>(
 #[cfg(feature = "http")]
 async fn read_http_node_items(
     client: &mut BufferedHttpRangeClient,
-    min_req_size: usize,
     base: usize,
     node_index: usize,
-    length: usize,
+    num_nodes: usize,
 ) -> Result<Vec<NodeItem>> {
     let begin = base + node_index * size_of::<NodeItem>();
-    let len = length * size_of::<NodeItem>();
+    let length = num_nodes * size_of::<NodeItem>();
     let bytes = client
-        .min_req_size(min_req_size)
-        .get_range(begin, len)
+        // we've  already determined precisely which nodes to fetch - no need for extra.
+        .min_req_size(0)
+        .get_range(begin, length)
         .await?;
 
-    let mut node_items = Vec::with_capacity(length);
-    for i in 0..length {
+    let mut node_items = Vec::with_capacity(num_nodes);
+    for i in 0..num_nodes {
         node_items.push(NodeItem::from_bytes(
             &bytes[i * size_of::<NodeItem>()..(i + 1) * size_of::<NodeItem>()],
         )?);
@@ -188,7 +188,7 @@ async fn read_http_node_items(
 pub struct SearchResultItem {
     /// Byte offset in feature data section
     pub offset: usize,
-    /// Feature number
+    /// Feature number (REVIEW: why do we need this?)
     pub index: usize,
 }
 
@@ -555,14 +555,19 @@ impl PackedRTree {
         min_y: f64,
         max_x: f64,
         max_y: f64,
-    ) -> Result<Vec<SearchResultItem>> {
+        combine_request_threshold: usize,
+    ) -> Result<Vec<HttpSearchResultItem>> {
         let bounds = NodeItem::bounds(min_x, min_y, max_x, max_y);
+        if num_items == 0 {
+            return Ok(vec![]);
+        }
         let level_bounds = PackedRTree::generate_level_bounds(num_items, node_size);
         let leaf_nodes_offset = level_bounds
             .first()
             .expect("RTree has at least one level when node_size >= 2 and num_items > 0")
             .0;
-        debug!("http_stream_search - index_begin: {index_begin}, num_items: {num_items}, node_size: {node_size}, level_bounds: {level_bounds:?}, GPS bounds:[({min_x}, {min_y}), ({max_x},{max_y})]");
+        let feature_begin = index_begin + PackedRTree::index_size(num_items, node_size);
+        debug!("http_stream_search - index_begin: {index_begin}, feature_begin: {feature_begin} num_items: {num_items}, node_size: {node_size}, level_bounds: {level_bounds:?}, GPS bounds:[({min_x}, {min_y}), ({max_x},{max_y})]");
 
         #[derive(Debug, PartialEq, Eq)]
         struct NodeRange {
@@ -582,34 +587,53 @@ impl PackedRTree {
                 "popped node: {next:?},  remaining queue len: {}",
                 queue.len()
             );
-            let node_index = next.nodes.start;
-            let is_leaf_node = node_index >= leaf_nodes_offset;
+            let start_node = next.nodes.start;
+            let is_leaf_node = start_node >= leaf_nodes_offset;
             // find the end index of the nodes
-            let end = min(
+            let mut end_node = min(
                 next.nodes.end + node_size as usize,
                 level_bounds[next.level].1,
             );
-            let length = end - node_index;
+            if is_leaf_node && end_node < num_items {
+                // We can infer the length of *this* feature by getting the start of the *next*
+                // feature, so we get an extra node.
+                // This approach doesn't work for the final node in the index,
+                // but in that case we know that the feature runs to the end of the FGB file and
+                // can make an open ended range request to get "the rest of the data".
+                end_node += 1;
+            }
+            let num_nodes = end_node - start_node;
             let node_items =
-                read_http_node_items(client, 0, index_begin, node_index, length).await?;
+                read_http_node_items(client, index_begin, start_node, num_nodes).await?;
 
             // search through child nodes
-            for pos in node_index..end {
-                let node_pos = pos - node_index;
+            for node_id in start_node..end_node {
+                let node_pos = node_id - start_node;
                 let node_item = &node_items[node_pos];
                 if !bounds.intersects(node_item) {
                     continue;
                 }
                 if is_leaf_node {
-                    results.push(SearchResultItem {
-                        offset: node_item.offset as usize,
-                        index: pos - leaf_nodes_offset,
-                    });
+                    let start = feature_begin + node_item.offset as usize;
+                    if let Some(next_node_item) = &node_items.get(node_pos + 1) {
+                        let end = feature_begin + next_node_item.offset as usize;
+                        results.push(HttpSearchResultItem {
+                            range: HttpRange::Range(start..end),
+                            index: node_id,
+                        });
+                    } else {
+                        debug_assert_eq!(node_pos, num_items);
+                        debug!("No next length (final item)");
+                        results.push(HttpSearchResultItem {
+                            range: HttpRange::RangeFrom(start..),
+                            index: node_id,
+                        });
+                    }
                     continue;
                 }
 
-                // request up to this many extra bytes if it means we can eliminate an extra request
-                let combine_request_threshold = 256 * 1024 / size_of::<NodeItem>();
+                let combine_request_node_threshold =
+                    combine_request_threshold / size_of::<NodeItem>();
 
                 // Add node to search recursion
                 match (queue.back_mut(), node_item.offset as usize) {
@@ -617,7 +641,7 @@ impl PackedRTree {
                     // Merge the ranges to avoid an extra request
                     (Some(tail), offset)
                         if tail.level == next.level - 1
-                            && offset < tail.nodes.end + combine_request_threshold =>
+                            && offset < tail.nodes.end + combine_request_node_threshold =>
                     {
                         debug_assert!(tail.nodes.end < offset);
                         tail.nodes.end = offset;
@@ -687,6 +711,59 @@ impl PackedRTree {
         self.extent.clone()
     }
 }
+
+#[cfg(feature = "http")]
+pub(crate) mod http {
+    use std::ops::{Range, RangeFrom};
+
+    /// Byte range within a file. Suitable for an HTTP Range request.
+    #[derive(Debug, Clone)]
+    pub enum HttpRange {
+        Range(Range<usize>),
+        RangeFrom(RangeFrom<usize>),
+    }
+
+    impl HttpRange {
+        pub fn start(&self) -> usize {
+            match self {
+                Self::Range(range) => range.start,
+                Self::RangeFrom(range) => range.start,
+            }
+        }
+
+        pub fn end(&self) -> Option<usize> {
+            match self {
+                Self::Range(range) => Some(range.end),
+                Self::RangeFrom(_) => None,
+            }
+        }
+
+        pub fn with_end(self, end: Option<usize>) -> Self {
+            match end {
+                Some(end) => Self::Range(self.start()..end),
+                None => Self::RangeFrom(self.start()..),
+            }
+        }
+
+        pub fn length(&self) -> Option<usize> {
+            match self {
+                Self::Range(range) => Some(range.end - range.start),
+                Self::RangeFrom(_) => None,
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    /// Bbox filter search result
+    pub struct HttpSearchResultItem {
+        /// Byte offset in feature data section
+        pub range: HttpRange,
+        /// Feature number (REVIEW: why do we need this?)
+        pub index: usize,
+    }
+}
+#[cfg(feature = "http")]
+pub(crate) use http::*;
 
 mod inspect {
     use super::*;


### PR DESCRIPTION
~~DRAFT: because it's based on #318 . Please review that first.~~ Merged!

When reading FGB over HTTP, most time is spent in the network, as opposed to local processing.

To minimize network round trips, we currently "over fetch" whenever we're getting feature data, in hopes of obviating a future request. For "select_all" queries this works great, because eventually we're going to need all the data anyway.

For bbox queries, we specifically don't want *all* the data.  Thanks to hilbert ordering, spatially nearby features are typically nearby on disk so we do OK with the same strategy, but inevitably we end up fetching data we don't end up using. 

The hilbert index contains the start location of every feature. We can infer the length of each feature by knowing where the _next_ feature starts. So we actually have all the information to fetch precisely the feature data we need for a given bbox.

So we could precisely fetch every feature individually to minimize bandwidth, but because network round trips are expensive, it still makes sense to "waste" some bytes and combine these feature requests. But now we can quantify exactly how many bytes we're willing to waste to obviate a separate request, and we don't bother fetching extra data when we know it's not useful.

I made a similar PR for JS/TS a while back (though that one also does concurrent fetching): https://github.com/flatgeobuf/flatgeobuf/pull/135

## Time improvements

Recall that our benchmarks are run against a simulated network which has 100ms latency and 50Mbps bandwidth.

```
medium select_bbox
time:   [636.61 ms 637.89 ms 639.27 ms]
change: [-41.733% -41.515% -41.296%] (p = 0.00 < 0.05)
Performance has improved.

medium bbox -> geojson
time:   [661.92 ms 663.29 ms 664.79 ms]
change: [-40.336% -40.172% -39.995%] (p = 0.00 < 0.05)
Performance has improved.
```

The rest of the benches are unaffected. Since `select_all`'s fetch strategy didn't change and bbox requests on small files already fit into the over-fetch of our initial header request, this is exactly as expected.

## Network improvements

In the above example, byte consumption was reduced from 4.25MB to 1.78MB

Before feature batching:
```
req_count: 6, body_bytes_sent: 4253968
```

With feature batching:
```
req_count: 6, body_bytes_sent: 1775808
```

Note that, in this particular case from our existing benches, the total number of requests were not reduced. But if the feature batches are close enough, and we're within our maximum request size, we will sometimes consolidate requests.

Note we still want to have _some_ maximum request size, because our current chunking approach stores the entire response in memory.
