### PR TITLE
[rust] CI clears cache when Cargo.toml changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             src/rust/target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('src/rust/Cargo.toml') }}
           restore-keys: ${{ runner.os }}-cargo-
       - run: cd src/rust && cargo test
 
@@ -139,6 +139,6 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             src/rust/target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('src/rust/Cargo.toml') }}
           restore-keys: ${{ runner.os }}-cargo-
       - run: cd src/rust && cargo test --no-default-features


### PR DESCRIPTION
Previously it was looking for Cargo.lock which we do not version control.

Note that because we do not commit Cargo.lock, that this approach will gradually pull in the latest dependencies as we rebuild.

If we want all dependencies to be built from cache, we'd need to commit a Cargo.lock. The downside to that approach is we might miss a breakage with a newer dependency release - one that users are likely to be using and that we should probably know about.
