### PR TITLE
Change bounds check for featureLength calc

### DIFF
--- a/src/ts/packedrtree.ts
+++ b/src/ts/packedrtree.ts
@@ -171,7 +171,7 @@ export async function* streamSearch(
 
             if (isLeafNode) {
                 const featureLength = (() => {
-                    if (pos < numItems - 1) {
+                    if (pos < end - 1) {
                         // Since features are tightly packed, we infer the
                         // length of _this_ feature by measuring to the _next_
                         // feature's start.


### PR DESCRIPTION
This seems to fix https://github.com/flatgeobuf/flatgeobuf/issues/329 but I'm not sure of all the why and consequences of it. Something seems off comparing pos to numItems.

I'm afraid I never quite understood this logic @michaelkirk.