### PR TITLE
TS: Add separate export sub-path for OpenLayers integration (Proof-of-Concept)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,18 @@
     "lib/**/*",
     "dist/**/*"
   ],
-  "types": "lib/mjs/flatgeobuf.d.ts",
-  "module": "lib/mjs/flatgeobuf.js",
-  "main": "lib/mjs/flatgeobuf.js",
+  "exports": {
+    ".": {
+      "import": "lib/mjs/flatgeobuf.js",
+      "require": "lib/mjs/flatgeobuf.js",
+      "types": "lib/mjs/flatgeobuf.d.ts"
+    },
+    "./ol": {
+      "import": "lib/mjs/ol.js",
+      "require": "lib/mjs/ol.js",
+      "types": "lib/mjs/ol.d.ts"
+    }
+  },
   "type": "module",
   "repository": {
     "type": "git",

--- a/src/ts/flatgeobuf.ts
+++ b/src/ts/flatgeobuf.ts
@@ -1,5 +1,4 @@
 export * as generic from './generic.js';
-export * as ol from './ol.js';
 export * as geojson from './geojson.js';
 
 export { Column } from './flat-geobuf/column.js';

--- a/src/ts/ol/ol.spec.ts
+++ b/src/ts/ol/ol.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 
-import { arrayToStream, takeAsync } from './streams/utils.js';
+import { arrayToStream, takeAsync } from '../streams/utils.js';
 import { deserialize, serialize } from './ol.js';
 
 import Feature from 'ol/Feature.js';

--- a/src/ts/ol/ol.ts
+++ b/src/ts/ol/ol.ts
@@ -1,4 +1,4 @@
-import { IFeature } from './generic/feature.js';
+import { IFeature } from '../generic/feature.js';
 import OlFeature from 'ol/Feature.js';
 
 import {
@@ -6,9 +6,9 @@ import {
     deserializeStream as fcDeserializeStream,
     deserializeFiltered as fcDeserializeFiltered,
     serialize as fcSerialize,
-} from './ol/featurecollection.js';
-import { HeaderMetaFn } from './generic.js';
-import { Rect } from './packedrtree.js';
+} from './featurecollection.js';
+import { HeaderMetaFn } from '../generic.js';
+import { Rect } from '../packedrtree.js';
 
 /**
  * Serialize OpenLayers Features to FlatGeobuf


### PR DESCRIPTION
Hi @bjornharrtell,

I am a big flatgeobuf fan and I am also maintaining the `@loaders.gl/flatgeobuf` module. As its usage is ramping up we have been running into a bunch of mostly bundling related problems, and we are now in the process of forking the flatgeobuf TS source code into loaders.gl (instead of importing the published module) so that we can fix these. 

In parallel, I thought I would open some PRs here to see if there is a reasonably smooth path to upstreaming changes. I am starting with a relatively small change in this PR to "test the waters". 

And no worries if this is too much to review or deal with right now, as mentioned we can always fork until the situation improves.

---

Description: Some TS applications are not using openlayers, so it would be helpful to isolate openlayers dependencies and code to a use a sub-path import. This lets flatgeobuf follow the principle that a data loading library should not include UI code by default.

```ts
import {...<non-ol exports>} from 'flatgeobuf';
import {...<ol-dependent exports>} from 'flatgeobuf/ol';
```

As written this will be a breaking change for OL users (they will need to update their import clauses'). If that is not acceptable we could add more export subpaths allowing apps to cherry-pick non-OL code, and keep the root export unchanged.

Note: This PR also moves all OL related files under the `ol` folder to emphasize the separation.