### PR TITLE
feat: Overloaded types for serialize()

### DIFF
--- a/src/ts/generic.ts
+++ b/src/ts/generic.ts
@@ -9,14 +9,49 @@ import { Rect } from './packedrtree.js';
 import { IFeature } from './generic/feature.js';
 import HeaderMeta from './header-meta.js';
 
+export { GeometryType } from './flat-geobuf/geometry-type.js';
+export { ColumnType } from './flat-geobuf/column-type.js';
+
+/** Callback function for receiving header metadata */
 export type HeaderMetaFn = (headerMeta: HeaderMeta) => void;
 
 /**
  * Deserialize FlatGeobuf into generic features
- * @param input Input byte array, stream or string
- * @param fromFeature Callback that recieves generic features
+ * @param input Input byte array
+ * @param fromFeature Callback that receives generic features
  * @param rect Filter rectangle
  */
+export function deserialize(
+    input: Uint8Array,
+    fromFeature: FromFeatureFn,
+    rect?: Rect,
+): IFeature[];
+
+/**
+ * Deserialize FlatGeobuf into generic features
+ * @param input Input string
+ * @param fromFeature Callback that receives generic features
+ * @param rect Filter rectangle
+ */
+export function deserialize(
+    input: string,
+    fromFeature: FromFeatureFn,
+    rect?: Rect,
+): AsyncGenerator<IFeature, any, unknown>;
+
+/**
+ * Deserialize FlatGeobuf into generic features
+ * @param input stream
+ * @param fromFeature Callback that receives generic features
+ * @param rect Filter rectangle
+ */
+export function deserialize(
+    input: ReadableStream,
+    fromFeature: FromFeatureFn,
+    rect?: Rect,
+): AsyncGenerator<IFeature>;
+
+/** Implementation */
 export function deserialize(
     input: Uint8Array | ReadableStream | string,
     fromFeature: FromFeatureFn,
@@ -30,6 +65,3 @@ export function deserialize(
 }
 
 export { serialize } from './generic/featurecollection.js';
-
-export { GeometryType } from './flat-geobuf/geometry-type.js';
-export { ColumnType } from './flat-geobuf/column-type.js';

--- a/src/ts/generic.ts
+++ b/src/ts/generic.ts
@@ -16,39 +16,38 @@ export { ColumnType } from './flat-geobuf/column-type.js';
 export type HeaderMetaFn = (headerMeta: HeaderMeta) => void;
 
 /**
- * Deserialize FlatGeobuf into generic features
- * @param input Input byte array
- * @param fromFeature Callback that receives generic features
- * @param rect Filter rectangle
- */
-export function deserialize(
-    input: Uint8Array,
-    fromFeature: FromFeatureFn,
-    rect?: Rect,
-): IFeature[];
-
-/**
- * Deserialize FlatGeobuf into generic features
+ * Deserialize FlatGeobuf from a URL into generic features
+ * @note Supports spatial filtering
  * @param input Input string
  * @param fromFeature Callback that receives generic features
  * @param rect Filter rectangle
  */
 export function deserialize(
-    input: string,
+    url: string,
     fromFeature: FromFeatureFn,
     rect?: Rect,
 ): AsyncGenerator<IFeature, any, unknown>;
 
 /**
- * Deserialize FlatGeobuf into generic features
- * @param input stream
+ * Deserialize FlatGeobuf from a typed array into generic features
+ * @note Does not support spatial filtering
+ * @param typedArray Input byte array
  * @param fromFeature Callback that receives generic features
- * @param rect Filter rectangle
+ */
+export function deserialize(
+    typedArray: Uint8Array,
+    fromFeature: FromFeatureFn,
+): IFeature[];
+
+/**
+ * Deserialize FlatGeobuf from a stream into generic features
+ * @note Does not support spatial filtering
+ * @param stream stream
+ * @param fromFeature Callback that receives generic features
  */
 export function deserialize(
     input: ReadableStream,
     fromFeature: FromFeatureFn,
-    rect?: Rect,
 ): AsyncGenerator<IFeature>;
 
 /** Implementation */
@@ -56,7 +55,7 @@ export function deserialize(
     input: Uint8Array | ReadableStream | string,
     fromFeature: FromFeatureFn,
     rect?: Rect,
-): any[] | AsyncGenerator<IFeature> {
+): IFeature[] | AsyncGenerator<IFeature> {
     if (input instanceof Uint8Array)
         return deserializeArray(input, fromFeature);
     else if (input instanceof ReadableStream)

--- a/src/ts/geojson.ts
+++ b/src/ts/geojson.ts
@@ -23,6 +23,7 @@ export function serialize(geojson: GeoJsonFeatureCollection): Uint8Array {
 /**
  * Deserialize FlatGeobuf into GeoJSON features
  * @param url Input string
+ * @param rect Filter rectangle - NOT USED
  * @param headerMetaFn Callback that will receive header metadata when available
  */
 export function deserialize(
@@ -35,10 +36,12 @@ export function deserialize(
  * Deserialize FlatGeobuf from a typed array into GeoJSON features
  * @note Does not support spatial filtering
  * @param typedArray Input byte array
+ * @param rect Filter rectangle - NOT USED
  * @param headerMetaFn Callback that will receive header metadata when available
  */
 export function deserialize(
     typedArray: Uint8Array,
+    rect?: Rect,
     headerMetaFn?: HeaderMetaFn,
 ): GeoJsonFeatureCollection;
 
@@ -46,22 +49,24 @@ export function deserialize(
  * Deserialize FlatGeobuf from a stream into GeoJSON features
  * @note Does not support spatial filtering
  * @param stream stream
+ * @param rect Filter rectangle
  * @param headerMetaFn Callback that will receive header metadata when available
  */
 export function deserialize(
     stream: ReadableStream,
+    rect?: Rect,
     headerMetaFn?: HeaderMetaFn,
 ): AsyncGenerator<IGeoJsonFeature>;
 
 /** Implementation */
 export function deserialize(
     input: Uint8Array | ReadableStream | string,
-    rectOrFn?: Rect | HeaderMetaFn,
+    rect?: Rect,
     headerMetaFn?: HeaderMetaFn,
 ): GeoJsonFeatureCollection | AsyncGenerator<IGeoJsonFeature> {
     if (input instanceof Uint8Array)
-        return fcDeserialize(input, rectOrFn as HeaderMetaFn);
+        return fcDeserialize(input, headerMetaFn);
     else if (input instanceof ReadableStream)
-        return fcDeserializeStream(input, rectOrFn as HeaderMetaFn);
-    else return fcDeserializeFiltered(input, rectOrFn as Rect, headerMetaFn);
+        return fcDeserializeStream(input, headerMetaFn);
+    else return fcDeserializeFiltered(input, rect!, headerMetaFn);
 }

--- a/src/ts/geojson.ts
+++ b/src/ts/geojson.ts
@@ -22,53 +22,46 @@ export function serialize(geojson: GeoJsonFeatureCollection): Uint8Array {
 
 /**
  * Deserialize FlatGeobuf into GeoJSON features
- * @param input Input byte array
- * @param fromFeature Callback that receives GeoJSON features
- * @param rect Filter rectangle
+ * @param url Input string
+ * @param headerMetaFn Callback that will receive header metadata when available
  */
 export function deserialize(
-    input: Uint8Array,
-    rect?: Rect,
-    headerMetaFn?: HeaderMetaFn,
-): GeoJsonFeatureCollection;
-
-/**
- * Deserialize FlatGeobuf into GeoJSON features
- * @param input Input string
- * @param fromFeature Callback that receives GeoJSON features
- * @param rect Filter rectangle
- */
-export function deserialize(
-    input: string,
+    url: string,
     rect?: Rect,
     headerMetaFn?: HeaderMetaFn,
 ): AsyncGenerator<IGeoJsonFeature, any, unknown>;
 
 /**
- * Deserialize FlatGeobuf into GeoJSON features
- * @param input stream
- * @param fromFeature Callback that receives GeoJSON features
- * @param rect Filter rectangle
+ * Deserialize FlatGeobuf from a typed array into GeoJSON features
+ * @note Does not support spatial filtering
+ * @param typedArray Input byte array
+ * @param headerMetaFn Callback that will receive header metadata when available
  */
 export function deserialize(
-    input: ReadableStream,
-    rect?: Rect,
-    headerMetaFn?: HeaderMetaFn
-): AsyncGenerator<IGeoJsonFeature>;
+    typedArray: Uint8Array,
+    headerMetaFn?: HeaderMetaFn,
+): GeoJsonFeatureCollection;
 
 /**
- * Deserialize FlatGeobuf into GeoJSON
- * @param input Input byte array, stream or string
- * @param rect Filter rectangle
- * @param headerMetaFn Callback that will recieve header metadata when available
+ * Deserialize FlatGeobuf from a stream into GeoJSON features
+ * @note Does not support spatial filtering
+ * @param stream stream
+ * @param headerMetaFn Callback that will receive header metadata when available
  */
 export function deserialize(
+    stream: ReadableStream,
+    headerMetaFn?: HeaderMetaFn,
+): AsyncGenerator<IGeoJsonFeature>;
+
+/** Implementation */
+export function deserialize(
     input: Uint8Array | ReadableStream | string,
-    rect?: Rect,
+    rectOrFn?: Rect | HeaderMetaFn,
     headerMetaFn?: HeaderMetaFn,
 ): GeoJsonFeatureCollection | AsyncGenerator<IGeoJsonFeature> {
-    if (input instanceof Uint8Array) return fcDeserialize(input, headerMetaFn);
+    if (input instanceof Uint8Array)
+        return fcDeserialize(input, rectOrFn as HeaderMetaFn);
     else if (input instanceof ReadableStream)
-        return fcDeserializeStream(input, headerMetaFn);
-    else return fcDeserializeFiltered(input, rect as Rect, headerMetaFn);
+        return fcDeserializeStream(input, rectOrFn as HeaderMetaFn);
+    else return fcDeserializeFiltered(input, rectOrFn as Rect, headerMetaFn);
 }

--- a/src/ts/geojson.ts
+++ b/src/ts/geojson.ts
@@ -11,7 +11,6 @@ import { Rect } from './packedrtree.js';
 import { IGeoJsonFeature } from './geojson/feature.js';
 import { HeaderMetaFn } from './generic.js';
 
-
 /**
  * Serialize GeoJSON to FlatGeobuf
  * @param geojson GeoJSON object to serialize
@@ -56,7 +55,6 @@ export function deserialize(
     rect?: Rect,
     headerMetaFn?: HeaderMetaFn
 ): AsyncGenerator<IGeoJsonFeature>;
-
 
 /**
  * Deserialize FlatGeobuf into GeoJSON

--- a/src/ts/geojson.ts
+++ b/src/ts/geojson.ts
@@ -64,8 +64,7 @@ export function deserialize(
     rect?: Rect,
     headerMetaFn?: HeaderMetaFn,
 ): GeoJsonFeatureCollection | AsyncGenerator<IGeoJsonFeature> {
-    if (input instanceof Uint8Array)
-        return fcDeserialize(input, headerMetaFn);
+    if (input instanceof Uint8Array) return fcDeserialize(input, headerMetaFn);
     else if (input instanceof ReadableStream)
         return fcDeserializeStream(input, headerMetaFn);
     else return fcDeserializeFiltered(input, rect!, headerMetaFn);

--- a/src/ts/geojson.ts
+++ b/src/ts/geojson.ts
@@ -11,6 +11,7 @@ import { Rect } from './packedrtree.js';
 import { IGeoJsonFeature } from './geojson/feature.js';
 import { HeaderMetaFn } from './generic.js';
 
+
 /**
  * Serialize GeoJSON to FlatGeobuf
  * @param geojson GeoJSON object to serialize
@@ -19,6 +20,43 @@ export function serialize(geojson: GeoJsonFeatureCollection): Uint8Array {
     const bytes = fcSerialize(geojson);
     return bytes;
 }
+
+/**
+ * Deserialize FlatGeobuf into GeoJSON features
+ * @param input Input byte array
+ * @param fromFeature Callback that receives GeoJSON features
+ * @param rect Filter rectangle
+ */
+export function deserialize(
+    input: Uint8Array,
+    rect?: Rect,
+    headerMetaFn?: HeaderMetaFn,
+): GeoJsonFeatureCollection;
+
+/**
+ * Deserialize FlatGeobuf into GeoJSON features
+ * @param input Input string
+ * @param fromFeature Callback that receives GeoJSON features
+ * @param rect Filter rectangle
+ */
+export function deserialize(
+    input: string,
+    rect?: Rect,
+    headerMetaFn?: HeaderMetaFn,
+): AsyncGenerator<IGeoJsonFeature, any, unknown>;
+
+/**
+ * Deserialize FlatGeobuf into GeoJSON features
+ * @param input stream
+ * @param fromFeature Callback that receives GeoJSON features
+ * @param rect Filter rectangle
+ */
+export function deserialize(
+    input: ReadableStream,
+    rect?: Rect,
+    headerMetaFn?: HeaderMetaFn
+): AsyncGenerator<IGeoJsonFeature>;
+
 
 /**
  * Deserialize FlatGeobuf into GeoJSON


### PR DESCRIPTION
Lost some time 
- before I realized that only the string variant of `deserialize()` accepts a filter rectangle. 
- Figuring out what type of data was returned based on input types.

Typescript overloading allows us to ensure return value types match input types, and looks like typedocs also generates separate entry for each overload. 

https://www.tutorialsteacher.com/typescript/function-overloading

Only supporting rect for http range requests seems like an unnecessary restriction, why not implement the filtering for all variants (even if we parse the library could avoiding calling callbacks for features outside an area of interest)