### PR TITLE
Prepare rust release 4.2.0

### DIFF
--- a/src/rust/CHANGELOG.md
+++ b/src/rust/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [4.2.0] - 2024-05-28
+
+- Fix "UnexpectedEof" error when bbox results includes first item.
+- Upgrade to geozero 0.13.0
+
 ## [4.1.0] - 2024-02-24
 
 - Potentially reduce requests for feature data by correctly including distance

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flatgeobuf"
-version = "4.1.0"
+version = "4.2.0"
 authors = ["Pirmin Kalberer <pka@sourcepole.ch>"]
 edition = "2021"
 description = "FlatGeobuf for Rust"


### PR DESCRIPTION
Based on https://github.com/flatgeobuf/flatgeobuf/pull/350.

It would be nice to cut a new release of rust flatgeobuf so that downstream projects can use flatgeobuf with geozero 0.13