### PR TITLE
Fix WASM build for Rust

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,7 +117,8 @@ jobs:
             src/rust/target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('src/rust/Cargo.toml') }}
           restore-keys: ${{ runner.os }}-cargo-
-      - run: cd src/rust && cargo test
+      - run: cd src/rust && cargo test && cargo check --target wasm32-unknown-unknown
+
 
   test-rust-no-default-features:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,6 +100,8 @@ jobs:
     steps:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
+      - name: Install wasm32-unknown-unknown target
+        run: rustup target add wasm32-unknown-unknown
       - name: Install Debian dependencies
         run: |
           export DEBIAN_FRONTEND=noninteractive
@@ -117,7 +119,10 @@ jobs:
             src/rust/target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('src/rust/Cargo.toml') }}
           restore-keys: ${{ runner.os }}-cargo-
-      - run: cd src/rust && cargo test && cargo check --target wasm32-unknown-unknown
+      - name: Tests
+        run: cd src/rust && cargo test
+      - name: Check wasm build
+        run: cd src/rust && cargo check --target wasm32-unknown-unknown
 
 
   test-rust-no-default-features:

--- a/src/rust/CHANGELOG.md
+++ b/src/rust/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix WASM build
+
 ## [4.2.0] - 2024-05-28
 
 - Fix "UnexpectedEof" error when bbox results includes first item.

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -19,7 +19,7 @@ http = ["http-range-client", "bytes", "reqwest"]
 flatbuffers = "23.5.26"
 byteorder = "1.5.0"
 geozero = { version = "0.13.0", default-features = false }
-http-range-client = { version = "0.7.2", optional = true }
+http-range-client = { version = "0.7.2", optional = true, default-features = false, features = ["reqwest-async"] }
 bytes = { version = "1.5.0", optional = true }
 log = "0.4.20"
 fallible-streaming-iterator = "0.1.9"


### PR DESCRIPTION
This lets the crate work in WASM. Without this fix, `http-range-client-0.7.2/src/reqwest_client.rs:77` tries to pull in `reqwest::blocking::Client`, which doesn't exist in WASM. This crate doesn't use the blocking HTTP client, so it's a very simple fix.

`cargo test` passes, and I have an end-to-end working FGB use in WASM at https://github.com/acteng/will-it-fit/blob/main/backend/src/lib.rs.