### PR TITLE
[rust] Upgrade to geozero 0.14

### DIFF
--- a/src/rust/CHANGELOG.md
+++ b/src/rust/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [4.4.0] - UNRELEASED
+
+- [rust] Upgrade to geozero 0.14
+
 ## [4.3.0] - 2024-08-16
 
 - [all] Upgrade to flatbuffers 24.3.25 (#380)

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -21,7 +21,7 @@ http = ["http-range-client", "bytes", "reqwest"]
 # Updates are typically synchronized across all FGB clients, and codegen should be rerun after updating.
 flatbuffers = "=24.3.25"
 byteorder = "1.5.0"
-geozero = { version = "0.13.0", default-features = false }
+geozero = { version = "0.14.0", default-features = false }
 http-range-client = { version = "0.8.0", optional = true, default-features = false, features = ["reqwest-async"] }
 bytes = { version = "1.5.0", optional = true }
 log = "0.4.20"
@@ -30,7 +30,7 @@ tempfile = "3.8.1"
 reqwest = { version = "0.12.5", optional = true }
 
 [dev-dependencies]
-geozero = { version = "0.13.0", default-features = true }
+geozero = { version = "0.14.0", default-features = true }
 seek_bufread = "1.2.2"
 rand = "0.8.5"
 hex = "0.4.3"


### PR DESCRIPTION
The Rust implementation should have a new release, because of major updates in `geozero`. Fixes #283 !