### PR TITLE
Rust: Add `geo-traits` reader implementation

### DIFF
--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -22,6 +22,7 @@ http = ["http-range-client", "bytes", "reqwest"]
 flatbuffers = "=24.3.25"
 byteorder = "1.5.0"
 geozero = { version = "0.14.0", default-features = false }
+geo-traits = "0.1.1"
 http-range-client = { version = "0.8.0", optional = true, default-features = false, features = ["reqwest-async"] }
 bytes = { version = "1.5.0", optional = true }
 log = "0.4.20"

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 documentation = "https://docs.rs/flatgeobuf/"
 license = "BSD-2-Clause"
 keywords = ["geo", "r-tree", "spatial"]
+rust-version = "1.82"
 
 [features]
 default = ["http"]

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -23,7 +23,7 @@ http = ["http-range-client", "bytes", "reqwest"]
 flatbuffers = "=24.3.25"
 byteorder = "1.5.0"
 geozero = { version = "0.14.0", default-features = false }
-geo-traits = "0.1.1"
+geo-traits = "0.2"
 http-range-client = { version = "0.8.0", optional = true, default-features = false, features = ["reqwest-async"] }
 bytes = { version = "1.5.0", optional = true }
 log = "0.4.20"

--- a/src/rust/src/error.rs
+++ b/src/rust/src/error.rs
@@ -10,6 +10,7 @@ pub enum Error {
     IllegalHeaderSize(usize),
     InvalidFlatbuffer(InvalidFlatbuffer),
     IO(std::io::Error),
+    UnsupportedGeometryType(String),
 }
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -23,6 +24,7 @@ impl Display for Error {
             Error::IllegalHeaderSize(size) => write!(f, "Illegal header size: {size}"),
             Error::InvalidFlatbuffer(invalid_flatbuffer) => invalid_flatbuffer.fmt(f),
             Error::IO(io) => io.fmt(f),
+            Error::UnsupportedGeometryType(s) => f.write_str(s),
         }
     }
 }

--- a/src/rust/src/geo_trait_impl.rs
+++ b/src/rust/src/geo_trait_impl.rs
@@ -34,7 +34,7 @@ impl<'a> CoordTrait for Coord<'a> {
             },
             3 => match self.dim {
                 Dimensions::Xyzm => self.geom.m().unwrap().get(self.coord_offset),
-                _ => unreachable!("Unreachable for 3D data"),
+                _ => unreachable!("Unreachable for 4D data"),
             },
             _ => panic!("Unexpected dim {n}"),
         }

--- a/src/rust/src/geo_trait_impl.rs
+++ b/src/rust/src/geo_trait_impl.rs
@@ -22,7 +22,7 @@ impl<'a> CoordTrait for Coord<'a> {
         self.dim
     }
 
-    fn nth_unchecked(&self, n: usize) -> Self::T {
+    fn nth_or_panic(&self, n: usize) -> Self::T {
         match n {
             0 => self.x(),
             1 => self.y(),

--- a/src/rust/src/geo_trait_impl.rs
+++ b/src/rust/src/geo_trait_impl.rs
@@ -1,0 +1,419 @@
+use geo_traits::{
+    CoordTrait, Dimensions, GeometryCollectionTrait, GeometryTrait, LineStringTrait,
+    MultiLineStringTrait, MultiPointTrait, MultiPolygonTrait, PointTrait, PolygonTrait,
+    UnimplementedLine, UnimplementedRect, UnimplementedTriangle,
+};
+
+#[derive(Debug, Clone)]
+pub struct Coord<'a> {
+    geom: crate::Geometry<'a>,
+    dim: Dimensions,
+    /// The coordinate offset
+    ///
+    /// Note each coord_offset points to an xy coordinate pair, and must be multiplied by 2 to get
+    /// the buffer coord_offset
+    coord_offset: usize,
+}
+
+impl<'a> CoordTrait for Coord<'a> {
+    type T = f64;
+
+    fn dim(&self) -> geo_traits::Dimensions {
+        self.dim
+    }
+
+    fn nth_unchecked(&self, n: usize) -> Self::T {
+        match n {
+            0 => self.geom.xy().unwrap().get(self.coord_offset * 2),
+            1 => self.geom.xy().unwrap().get((self.coord_offset * 2) + 1),
+            2 => self.geom.z().unwrap().get(self.coord_offset),
+            _ => panic!("Unexpected dim {n}"),
+        }
+    }
+
+    fn x(&self) -> Self::T {
+        self.geom.xy().unwrap().get(self.coord_offset * 2)
+    }
+
+    fn y(&self) -> Self::T {
+        self.geom.xy().unwrap().get((self.coord_offset * 2) + 1)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Point<'a> {
+    geom: crate::Geometry<'a>,
+    dim: Dimensions,
+    /// The coordinate offset
+    ///
+    /// Note each coord_offset points to an xy coordinate pair, and must be multiplied by 2 to get
+    /// the buffer coord_offset
+    coord_offset: usize,
+}
+
+impl<'a> Point<'a> {
+    pub(super) fn new(geom: crate::Geometry<'a>, dim: Dimensions) -> Self {
+        Self {
+            geom,
+            dim,
+            coord_offset: 0,
+        }
+    }
+}
+
+impl<'a> PointTrait for Point<'a> {
+    type T = f64;
+    type CoordType<'b> = Coord<'a> where Self: 'b;
+
+    fn dim(&self) -> geo_traits::Dimensions {
+        self.dim
+    }
+
+    fn coord(&self) -> Option<Self::CoordType<'_>> {
+        // FlatGeobuf doesn't support empty geometries
+        Some(Coord {
+            geom: self.geom,
+            dim: self.dim,
+            coord_offset: self.coord_offset,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LineString<'a> {
+    geom: crate::Geometry<'a>,
+    dim: Dimensions,
+
+    /// This coord_offset will be non-zero when the LineString is a reference onto an external
+    /// geometry, e.g. a Polygon
+    coord_offset: usize,
+
+    /// This length cannot be inferred from the underlying buffer when this LineString is a
+    /// reference on e.g. a Polygon
+    length: usize,
+}
+
+impl<'a> LineString<'a> {
+    pub(super) fn new(geom: crate::Geometry<'a>, dim: Dimensions) -> Self {
+        let length = geom.xy().unwrap().len() / 2;
+        Self {
+            geom,
+            dim,
+            coord_offset: 0,
+            length,
+        }
+    }
+}
+
+impl<'a> LineStringTrait for LineString<'a> {
+    type T = f64;
+    type CoordType<'b> = Coord<'a> where Self: 'b;
+
+    fn dim(&self) -> geo_traits::Dimensions {
+        self.dim
+    }
+
+    fn num_coords(&self) -> usize {
+        self.length
+    }
+
+    unsafe fn coord_unchecked(&self, i: usize) -> Self::CoordType<'_> {
+        Coord {
+            geom: self.geom,
+            dim: self.dim,
+            coord_offset: self.coord_offset + i,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Polygon<'a> {
+    geom: crate::Geometry<'a>,
+    dim: Dimensions,
+}
+
+impl<'a> Polygon<'a> {
+    pub(super) fn new(geom: crate::Geometry<'a>, dim: Dimensions) -> Self {
+        Self { geom, dim }
+    }
+}
+
+impl<'a> PolygonTrait for Polygon<'a> {
+    type T = f64;
+    type RingType<'b> = LineString<'a> where Self: 'b;
+
+    fn dim(&self) -> geo_traits::Dimensions {
+        self.dim
+    }
+
+    fn num_interiors(&self) -> usize {
+        if let Some(ends) = self.geom.ends() {
+            ends.len() - 1
+        } else {
+            0
+        }
+    }
+
+    fn exterior(&self) -> Option<Self::RingType<'_>> {
+        if let Some(ends) = self.geom.ends() {
+            let exterior_end = ends.get(0);
+            Some(LineString {
+                geom: self.geom,
+                dim: self.dim,
+                coord_offset: 0,
+                length: exterior_end.try_into().unwrap(),
+            })
+        } else {
+            Some(LineString::new(self.geom, self.dim))
+        }
+    }
+
+    unsafe fn interior_unchecked(&self, i: usize) -> Self::RingType<'_> {
+        let ends = self.geom.ends().unwrap();
+        let start = ends.get(i);
+        let end = ends.get(i + 1);
+        LineString {
+            geom: self.geom,
+            dim: self.dim,
+            coord_offset: start.try_into().unwrap(),
+            length: (end - start).try_into().unwrap(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MultiPoint<'a> {
+    geom: crate::Geometry<'a>,
+    dim: Dimensions,
+
+    /// This coord_offset will be non-zero when the MultiPoint is a reference onto an external
+    /// geometry, e.g. a GeometryCollection
+    coord_offset: usize,
+
+    /// This length is not inferred from the underlying buffer because this MultiPoint could be a
+    /// reference on e.g. a GeometryCollection
+    length: usize,
+}
+
+impl<'a> MultiPoint<'a> {
+    pub(super) fn new(geom: crate::Geometry<'a>, dim: Dimensions) -> Self {
+        let length = geom.xy().unwrap().len() / 2;
+        Self {
+            geom,
+            dim,
+            coord_offset: 0,
+            length,
+        }
+    }
+}
+
+impl<'a> MultiPointTrait for MultiPoint<'a> {
+    type T = f64;
+    type PointType<'b> = Point<'a> where Self: 'b;
+
+    fn dim(&self) -> geo_traits::Dimensions {
+        self.dim
+    }
+
+    fn num_points(&self) -> usize {
+        self.length
+    }
+
+    unsafe fn point_unchecked(&self, i: usize) -> Self::PointType<'_> {
+        Point {
+            geom: self.geom,
+            dim: self.dim,
+            coord_offset: self.coord_offset + i,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MultiLineString<'a> {
+    geom: crate::Geometry<'a>,
+    dim: Dimensions,
+}
+
+impl<'a> MultiLineString<'a> {
+    pub(super) fn new(geom: crate::Geometry<'a>, dim: Dimensions) -> Self {
+        Self { geom, dim }
+    }
+}
+
+impl<'a> MultiLineStringTrait for MultiLineString<'a> {
+    type T = f64;
+    type LineStringType<'b> = LineString<'a> where Self: 'b;
+
+    fn dim(&self) -> geo_traits::Dimensions {
+        self.dim
+    }
+
+    fn num_line_strings(&self) -> usize {
+        if let Some(ends) = self.geom.ends() {
+            ends.len()
+        } else {
+            1
+        }
+    }
+
+    unsafe fn line_string_unchecked(&self, i: usize) -> Self::LineStringType<'_> {
+        if let Some(ends) = self.geom.ends() {
+            let start = if i == 0 { 0 } else { ends.get(i - 1) };
+            let end = ends.get(i);
+            LineString {
+                geom: self.geom,
+                dim: self.dim,
+                coord_offset: start.try_into().unwrap(),
+                length: (end - start).try_into().unwrap(),
+            }
+        } else {
+            assert_eq!(i, 0);
+            LineString::new(self.geom, self.dim)
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MultiPolygon<'a> {
+    geom: crate::Geometry<'a>,
+    dim: Dimensions,
+}
+
+impl<'a> MultiPolygon<'a> {
+    pub(super) fn new(geom: crate::Geometry<'a>, dim: Dimensions) -> Self {
+        Self { geom, dim }
+    }
+}
+
+impl<'a> MultiPolygonTrait for MultiPolygon<'a> {
+    type T = f64;
+    type PolygonType<'b> = Polygon<'a> where Self: 'b;
+
+    fn dim(&self) -> geo_traits::Dimensions {
+        self.dim
+    }
+
+    fn num_polygons(&self) -> usize {
+        self.geom.parts().unwrap().len()
+    }
+
+    unsafe fn polygon_unchecked(&self, i: usize) -> Self::PolygonType<'_> {
+        Polygon {
+            geom: self.geom.parts().unwrap().get(i),
+            dim: self.dim,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum Geometry<'a> {
+    Point(Point<'a>),
+    LineString(LineString<'a>),
+    Polygon(Polygon<'a>),
+    MultiPoint(MultiPoint<'a>),
+    MultiLineString(MultiLineString<'a>),
+    MultiPolygon(MultiPolygon<'a>),
+    #[allow(clippy::enum_variant_names)]
+    GeometryCollection(GeometryCollection<'a>),
+}
+
+impl<'a> Geometry<'a> {
+    pub(super) fn new(geom: crate::Geometry<'a>, dim: Dimensions) -> Self {
+        match geom.type_() {
+            crate::GeometryType::Point => Self::Point(Point::new(geom, dim)),
+            crate::GeometryType::LineString => Self::LineString(LineString::new(geom, dim)),
+            crate::GeometryType::Polygon => Self::Polygon(Polygon::new(geom, dim)),
+            crate::GeometryType::MultiPoint => Self::MultiPoint(MultiPoint::new(geom, dim)),
+            crate::GeometryType::MultiLineString => {
+                Self::MultiLineString(MultiLineString::new(geom, dim))
+            }
+            crate::GeometryType::MultiPolygon => Self::MultiPolygon(MultiPolygon::new(geom, dim)),
+            crate::GeometryType::GeometryCollection => {
+                Self::GeometryCollection(GeometryCollection::new(geom, dim))
+            }
+            t => panic!("Unexpected type {t:?}"),
+        }
+    }
+}
+
+impl<'a> GeometryTrait for Geometry<'a> {
+    type T = f64;
+    type PointType<'b> = Point<'a> where Self: 'b;
+    type LineStringType<'b> = LineString<'a> where Self: 'b;
+    type PolygonType<'b> = Polygon<'a> where Self: 'b;
+    type MultiPointType<'b> = MultiPoint<'a> where Self: 'b;
+    type MultiLineStringType<'b> = MultiLineString<'a> where Self: 'b;
+    type MultiPolygonType<'b> = MultiPolygon<'a> where Self: 'b;
+    type GeometryCollectionType<'b> = GeometryCollection<'a> where Self: 'b;
+    type RectType<'b> = UnimplementedRect<f64> where Self: 'b;
+    type TriangleType<'b> = UnimplementedTriangle<f64> where Self: 'b;
+    type LineType<'b> = UnimplementedLine<f64> where Self: 'b;
+
+    fn dim(&self) -> geo_traits::Dimensions {
+        match self {
+            Self::Point(g) => PointTrait::dim(g),
+            Self::LineString(g) => g.dim(),
+            Self::Polygon(g) => g.dim(),
+            Self::MultiPoint(g) => g.dim(),
+            Self::MultiLineString(g) => g.dim(),
+            Self::MultiPolygon(g) => g.dim(),
+            Self::GeometryCollection(g) => g.dim(),
+        }
+    }
+
+    fn as_type(
+        &self,
+    ) -> geo_traits::GeometryType<
+        '_,
+        Point<'a>,
+        LineString<'a>,
+        Polygon<'a>,
+        MultiPoint<'a>,
+        MultiLineString<'a>,
+        MultiPolygon<'a>,
+        GeometryCollection<'a>,
+        UnimplementedRect<f64>,
+        UnimplementedTriangle<f64>,
+        UnimplementedLine<f64>,
+    > {
+        match self {
+            Self::Point(pt) => geo_traits::GeometryType::Point(pt),
+            Self::LineString(pt) => geo_traits::GeometryType::LineString(pt),
+            Self::Polygon(pt) => geo_traits::GeometryType::Polygon(pt),
+            Self::MultiPoint(pt) => geo_traits::GeometryType::MultiPoint(pt),
+            Self::MultiLineString(pt) => geo_traits::GeometryType::MultiLineString(pt),
+            Self::MultiPolygon(pt) => geo_traits::GeometryType::MultiPolygon(pt),
+            Self::GeometryCollection(pt) => geo_traits::GeometryType::GeometryCollection(pt),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GeometryCollection<'a> {
+    geom: crate::Geometry<'a>,
+    dim: Dimensions,
+}
+
+impl<'a> GeometryCollection<'a> {
+    pub(super) fn new(geom: crate::Geometry<'a>, dim: Dimensions) -> Self {
+        Self { geom, dim }
+    }
+}
+
+impl<'a> GeometryCollectionTrait for GeometryCollection<'a> {
+    type T = f64;
+    type GeometryType<'b> = Geometry<'a> where Self: 'b;
+
+    fn dim(&self) -> geo_traits::Dimensions {
+        self.dim
+    }
+
+    fn num_geometries(&self) -> usize {
+        let parts = self.geom.parts().unwrap();
+        parts.len()
+    }
+
+    unsafe fn geometry_unchecked(&self, i: usize) -> Self::GeometryType<'_> {
+        Geometry::new(self.geom.parts().unwrap().get(i), self.dim)
+    }
+}

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -93,7 +93,7 @@
 //! while let Some(feature) = fgb.next()? {
 //!     println!("{}", feature.property::<String>("name").unwrap());
 //!     // Assert that each feature is a multi polygon type
-//!     assert_multi_polygon(&feature.geometry_trait());
+//!     assert_multi_polygon(&feature.geometry_trait().unwrap().unwrap());
 //! }
 //! # Ok(())
 //! # }

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -77,6 +77,7 @@ mod feature_generated;
 mod feature_writer;
 mod file_reader;
 mod file_writer;
+mod geo_trait_impl;
 mod geometry_reader;
 #[allow(unused_imports, non_snake_case, clippy::all)]
 #[rustfmt::skip]

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -64,6 +64,41 @@
 //! # }
 //! ```
 //!
+//! ## [`geo_traits`] integration
+//!
+//! This crate integrates with [`geo_traits`] for easy zero-copy vector data interoperability.
+//! It can be easier to use than geozero in some cases because you get _random access_ to the
+//! underlying coordinates, rather than needing to receive a stream of coordinates. This means that
+//! you can write algorithms based on `geo_traits` and pass in FlatGeobuf objects _directly_.
+//! Because the underlying Flatbuffers support zero-copy access, you could even memory-map a
+//! FlatGeobuf file directly.
+//!
+//! Use [`FgbFeature::geometry_trait`] to access an opaque object that implements
+//! [`geo_traits::GeometryTrait`]. Then with [`geo_traits::GeometryTrait::as_type`] you can match
+//! on the geometry type, downcasting to a trait implementation of concrete type.
+//!
+//! ```rust
+//! use flatgeobuf::*;
+//! use geo_traits::{GeometryTrait, GeometryType};
+//! # use std::fs::File;
+//! # use std::io::BufReader;
+//!
+//! fn assert_multi_polygon(geom: &impl GeometryTrait<T = f64>) {
+//!     assert!(matches!(geom.as_type(), GeometryType::MultiPolygon(_)))
+//! }
+//!
+//! # fn read_fgb() -> std::result::Result<(), Box<dyn std::error::Error>> {
+//! let mut filein = BufReader::new(File::open("countries.fgb")?);
+//! let mut fgb = FgbReader::open(&mut filein)?.select_all()?;
+//! while let Some(feature) = fgb.next()? {
+//!     println!("{}", feature.property::<String>("name").unwrap());
+//!     // Assert that each feature is a multi polygon type
+//!     assert_multi_polygon(&feature.geometry_trait());
+//! }
+//! # Ok(())
+//! # }
+//! ```
+//!
 
 #![allow(clippy::manual_range_contains)]
 

--- a/src/rust/src/properties_reader.rs
+++ b/src/rust/src/properties_reader.rs
@@ -42,7 +42,9 @@ impl FgbFeature {
     ///
     /// Note that this method only supports the core geometry types supported by [geo_traits], and
     /// will panic on curve geometries.
-    pub fn geometry_trait_impl(&self) -> Result<Option<impl geo_traits::GeometryTrait + use<'_>>> {
+    pub fn geometry_trait_impl(
+        &self,
+    ) -> Result<Option<impl geo_traits::GeometryTrait<T = f64> + use<'_>>> {
         if let Some(geom) = self.geometry() {
             let dim = self.dimension();
             let result = match self.header().geometry_type() {

--- a/src/rust/src/properties_reader.rs
+++ b/src/rust/src/properties_reader.rs
@@ -42,37 +42,45 @@ impl FgbFeature {
     ///
     /// Note that this method only supports the core geometry types supported by [geo_traits], and
     /// will panic on curve geometries.
-    pub fn geometry_trait_impl(&self) -> Option<impl geo_traits::GeometryTrait + use<'_>> {
-        let geom = self.geometry()?;
-        let dim = self.dimension();
-        let result = match self.header().geometry_type() {
-            GeometryType::Point => {
-                crate::geo_trait_impl::Geometry::Point(crate::geo_trait_impl::Point::new(geom, dim))
-            }
-            GeometryType::LineString => crate::geo_trait_impl::Geometry::LineString(
-                crate::geo_trait_impl::LineString::new(geom, dim),
-            ),
-            GeometryType::Polygon => crate::geo_trait_impl::Geometry::Polygon(
-                crate::geo_trait_impl::Polygon::new(geom, dim),
-            ),
-            GeometryType::MultiPoint => crate::geo_trait_impl::Geometry::MultiPoint(
-                crate::geo_trait_impl::MultiPoint::new(geom, dim),
-            ),
-            GeometryType::MultiLineString => crate::geo_trait_impl::Geometry::MultiLineString(
-                crate::geo_trait_impl::MultiLineString::new(geom, dim),
-            ),
-            GeometryType::MultiPolygon => crate::geo_trait_impl::Geometry::MultiPolygon(
-                crate::geo_trait_impl::MultiPolygon::new(geom, dim),
-            ),
-            GeometryType::Unknown => crate::geo_trait_impl::Geometry::new(geom, dim),
-            GeometryType::GeometryCollection => {
-                crate::geo_trait_impl::Geometry::GeometryCollection(
-                    crate::geo_trait_impl::GeometryCollection::new(geom, dim),
-                )
-            }
-            _ => todo!("How should we handle other geometry types here?"),
-        };
-        Some(result)
+    pub fn geometry_trait_impl(&self) -> Result<Option<impl geo_traits::GeometryTrait + use<'_>>> {
+        if let Some(geom) = self.geometry() {
+            let dim = self.dimension();
+            let result = match self.header().geometry_type() {
+                GeometryType::Point => crate::geo_trait_impl::Geometry::Point(
+                    crate::geo_trait_impl::Point::new(geom, dim),
+                ),
+                GeometryType::LineString => crate::geo_trait_impl::Geometry::LineString(
+                    crate::geo_trait_impl::LineString::new(geom, dim),
+                ),
+                GeometryType::Polygon => crate::geo_trait_impl::Geometry::Polygon(
+                    crate::geo_trait_impl::Polygon::new(geom, dim),
+                ),
+                GeometryType::MultiPoint => crate::geo_trait_impl::Geometry::MultiPoint(
+                    crate::geo_trait_impl::MultiPoint::new(geom, dim),
+                ),
+                GeometryType::MultiLineString => crate::geo_trait_impl::Geometry::MultiLineString(
+                    crate::geo_trait_impl::MultiLineString::new(geom, dim),
+                ),
+                GeometryType::MultiPolygon => crate::geo_trait_impl::Geometry::MultiPolygon(
+                    crate::geo_trait_impl::MultiPolygon::new(geom, dim),
+                ),
+                GeometryType::Unknown => crate::geo_trait_impl::Geometry::new(geom, dim),
+                GeometryType::GeometryCollection => {
+                    crate::geo_trait_impl::Geometry::GeometryCollection(
+                        crate::geo_trait_impl::GeometryCollection::new(geom, dim),
+                    )
+                }
+                geom_type => {
+                    return Err(GeozeroError::Geometry(format!(
+                        "Unsupported geometry type in geo-traits: {:?}",
+                        geom_type
+                    )))
+                }
+            };
+            Ok(Some(result))
+        } else {
+            Ok(None)
+        }
     }
 }
 

--- a/src/rust/src/properties_reader.rs
+++ b/src/rust/src/properties_reader.rs
@@ -38,11 +38,17 @@ impl FgbFeature {
     }
 
     /// Access the underlying geometry, returning an object that implements
-    /// [geo_traits::GeometryTrait].
+    /// [`geo_traits::GeometryTrait`].
     ///
-    /// Note that this method only supports the core geometry types supported by [geo_traits], and
-    /// will panic on curve geometries.
-    pub fn geometry_trait_impl(
+    /// This allows for random-access zero-copy vector data interoperability, even with Z, M, and
+    /// ZM geometries that `geo_types` does not currently support.
+    ///
+    /// ### Notes:
+    ///
+    /// - Any `T` values are currently ignored.
+    /// - This will error on curve geometries since they are not among the core geometry types
+    ///   supported by [`geo_traits`].
+    pub fn geometry_trait(
         &self,
     ) -> std::result::Result<Option<impl geo_traits::GeometryTrait<T = f64> + use<'_>>, crate::Error>
     {

--- a/src/rust/src/properties_reader.rs
+++ b/src/rust/src/properties_reader.rs
@@ -27,6 +27,53 @@ impl FgbFeature {
     pub fn geometry(&self) -> Option<Geometry> {
         self.fbs_feature().geometry()
     }
+
+    fn dimension(&self) -> geo_traits::Dimensions {
+        match (self.header().has_z(), self.header().has_m()) {
+            (true, true) => geo_traits::Dimensions::Xyzm,
+            (true, false) => geo_traits::Dimensions::Xyz,
+            (false, true) => geo_traits::Dimensions::Xym,
+            (false, false) => geo_traits::Dimensions::Xy,
+        }
+    }
+
+    /// Access the underlying geometry, returning an object that implements
+    /// [geo_traits::GeometryTrait].
+    ///
+    /// Note that this method only supports the core geometry types supported by [geo_traits], and
+    /// will panic on curve geometries.
+    pub fn geometry_trait_impl(&self) -> Option<impl geo_traits::GeometryTrait + use<'_>> {
+        let geom = self.geometry()?;
+        let dim = self.dimension();
+        let result = match self.header().geometry_type() {
+            GeometryType::Point => {
+                crate::geo_trait_impl::Geometry::Point(crate::geo_trait_impl::Point::new(geom, dim))
+            }
+            GeometryType::LineString => crate::geo_trait_impl::Geometry::LineString(
+                crate::geo_trait_impl::LineString::new(geom, dim),
+            ),
+            GeometryType::Polygon => crate::geo_trait_impl::Geometry::Polygon(
+                crate::geo_trait_impl::Polygon::new(geom, dim),
+            ),
+            GeometryType::MultiPoint => crate::geo_trait_impl::Geometry::MultiPoint(
+                crate::geo_trait_impl::MultiPoint::new(geom, dim),
+            ),
+            GeometryType::MultiLineString => crate::geo_trait_impl::Geometry::MultiLineString(
+                crate::geo_trait_impl::MultiLineString::new(geom, dim),
+            ),
+            GeometryType::MultiPolygon => crate::geo_trait_impl::Geometry::MultiPolygon(
+                crate::geo_trait_impl::MultiPolygon::new(geom, dim),
+            ),
+            GeometryType::Unknown => crate::geo_trait_impl::Geometry::new(geom, dim),
+            GeometryType::GeometryCollection => {
+                crate::geo_trait_impl::Geometry::GeometryCollection(
+                    crate::geo_trait_impl::GeometryCollection::new(geom, dim),
+                )
+            }
+            _ => todo!("How should we handle other geometry types here?"),
+        };
+        Some(result)
+    }
 }
 
 impl geozero::FeatureAccess for FgbFeature {}

--- a/src/rust/src/properties_reader.rs
+++ b/src/rust/src/properties_reader.rs
@@ -44,7 +44,8 @@ impl FgbFeature {
     /// will panic on curve geometries.
     pub fn geometry_trait_impl(
         &self,
-    ) -> Result<Option<impl geo_traits::GeometryTrait<T = f64> + use<'_>>> {
+    ) -> std::result::Result<Option<impl geo_traits::GeometryTrait<T = f64> + use<'_>>, crate::Error>
+    {
         if let Some(geom) = self.geometry() {
             let dim = self.dimension();
             let result = match self.header().geometry_type() {
@@ -73,7 +74,7 @@ impl FgbFeature {
                     )
                 }
                 geom_type => {
-                    return Err(GeozeroError::Geometry(format!(
+                    return Err(crate::Error::UnsupportedGeometryType(format!(
                         "Unsupported geometry type in geo-traits: {:?}",
                         geom_type
                     )))


### PR DESCRIPTION
We have a new core `geo` crate: [`geo-traits`](https://docs.rs/geo-traits/latest/geo_traits/)! This enables zero-copy vector data interchange throughout the GeoRust ecosystem.

This PR implements these traits on new-types around a `flatgeobuf::Geometry`.

Since Flatbuffers are zero-copy, this means that you could memory-map a FlatGeobuf file and pass those geometry references directly to any consumer accepting these traits.

### Change list 

- Adds a public method onto `FgbFeature` to return a struct that implements `geo_traits::GeometryTrait`.
- Since the method returns an `impl geo_traits::GeometryTrait`, none of the new structs need to be exposed publicly.
- This provides a standard way to access FlatGeobuf data with Z and M values as well.

### Questions

- How to handle FlatGeobuf files with `t` values? Those are currently omitted
- How should we handle curve types? This PR currently panics on those.