### PR TITLE
[ts] fix missing binary typed properties

### DIFF
--- a/src/ts/generic/featurecollection.ts
+++ b/src/ts/generic/featurecollection.ts
@@ -11,7 +11,7 @@ import { Feature } from '../flat-geobuf/feature.js';
 import type HeaderMeta from '../header-meta.js';
 import { fromByteBuffer } from '../header-meta.js';
 
-import { buildFeature, type IFeature } from './feature.js';
+import { buildFeature, type IProperties, type IFeature } from './feature.js';
 import { HttpReader } from '../http-reader.js';
 import { type Rect, calcTreeSize } from '../packedrtree.js';
 import { parseGeometry } from './geometry.js';
@@ -198,21 +198,21 @@ export function buildHeader(
     return builder.asUint8Array() as Uint8Array;
 }
 
-function valueToType(value: boolean | number | string | undefined): ColumnType {
+function valueToType(
+    value: boolean | number | string | Uint8Array | undefined,
+): ColumnType {
     if (typeof value === 'boolean') return ColumnType.Bool;
     else if (typeof value === 'number')
         if (value % 1 === 0) return ColumnType.Int;
         else return ColumnType.Double;
     else if (typeof value === 'string') return ColumnType.String;
     else if (value === null) return ColumnType.String;
+    else if (value instanceof Uint8Array) return ColumnType.Binary;
     else if (typeof value === 'object') return ColumnType.Json;
     else throw new Error(`Unknown type (value '${value}')`);
 }
 
-export function mapColumn(
-    properties: Record<string, string | number | boolean | undefined>,
-    k: string,
-): ColumnMeta {
+export function mapColumn(properties: IProperties, k: string): ColumnMeta {
     return {
         name: k,
         type: valueToType(properties[k]),

--- a/src/ts/geojson.spec.ts
+++ b/src/ts/geojson.spec.ts
@@ -24,14 +24,20 @@ import {
 
 function makeFeatureCollection(
     wkt: string,
-    properties?: Record<string, string | number | boolean | object | undefined>,
+    properties?: Record<
+        string,
+        string | number | boolean | object | Uint8Array | undefined
+    >,
 ) {
     return makeFeatureCollectionFromArray([wkt], properties);
 }
 
 function makeFeatureCollectionFromArray(
     wkts: string[],
-    properties?: Record<string, string | number | boolean | object | undefined>,
+    properties?: Record<
+        string,
+        string | number | boolean | object | Uint8Array | undefined
+    >,
 ) {
     const reader = new WKTReader();
     const writer = new GeoJSONWriter();
@@ -370,6 +376,14 @@ describe('geojson module', () => {
         it('Json Value', () => {
             const expected = makeFeatureCollection('POINT(1 1)', {
                 test: { hello: 'world' },
+            });
+            const actual = deserialize(serialize(expected));
+            expect(actual).to.deep.equal(expected);
+        });
+
+        it('Binary', () => {
+            const expected = makeFeatureCollection('POINT(1 1)', {
+                test: new Uint8Array([116, 101, 115, 116]),
             });
             const actual = deserialize(serialize(expected));
             expect(actual).to.deep.equal(expected);

--- a/src/ts/ol/feature.ts
+++ b/src/ts/ol/feature.ts
@@ -5,6 +5,7 @@ import type HeaderMeta from '../header-meta.js';
 import { createGeometry } from './geometry.js';
 import {
     fromFeature as genericFromFeature,
+    type IProperties,
     type IFeature,
 } from '../generic/feature.js';
 import { type ISimpleGeometry } from '../generic/geometry.js';
@@ -12,7 +13,7 @@ import { type ISimpleGeometry } from '../generic/geometry.js';
 function createFeature(
     id: number,
     geometry?: ISimpleGeometry,
-    properties?: Record<string, string | number | boolean | undefined>,
+    properties?: IProperties,
 ): IFeature {
     const olFeature = new OlFeature(geometry);
     olFeature.setId(id);


### PR DESCRIPTION
The FGB specification and the column type declarations included binary properties, but these properties were not implemented in the TypeScript code for de/serialization.

This commit adds the necessary logic to handle parsing of binary typed properties, ensuring full compliance with the FGB specification.