### PR TITLE
Rust: Expose `Seekable` and `NotSeekable` marker structs

### DIFF
--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -124,6 +124,7 @@ mod properties_reader;
 
 pub use error::{Error, Result};
 pub use feature_generated::*;
+pub use file_reader::reader_trait::*;
 pub use file_reader::*;
 pub use file_writer::*;
 pub use geometry_reader::*;


### PR DESCRIPTION
In [geoarrow-rs](https://github.com/geoarrow/geoarrow-rs) I'm wrapping the flatgeobuf crate to expose FlatGeobuf as an Arrow data source. This has the nice benefit of making extremely fast bindings to Python and JavaScript. Depending on how you measure, it's roughly the same speed as GDAL's FlatGeobuf reader + Arrow binding to Python, but with some added benefits like being an easy-to-install static executable, ease of compilation to WebAssembly, and removing some of GDAL's arguable baggage.

But so far, the bindings load all the data upfront and materialize it all in memory. In https://github.com/geoarrow/geoarrow-rs/pull/933 I have a compiling prototype of a [_`RecordBatchReader`_](https://docs.rs/arrow/latest/arrow/array/trait.RecordBatchReader.html) implementation of reading FlatGeobuf. You can 

The gist is this:

```rs
pub struct FlatGeobufReaderBuilder<R> {
    reader: FgbReader<R>,
}

impl<R: Read> FlatGeobufReaderBuilder<R> {
    pub fn open(reader: R) -> Result<Self>;

    pub fn read_seq(
        self,
        bbox: (f64, f64, f64, f64),
    ) -> Result<FlatGeobufRecordBatchReader<R, NotSeekable>>;
}

impl<R: Read + Seek> FlatGeobufReaderBuilder<R> {
    pub fn read(
        self,
        bbox: (f64, f64, f64, f64),
    ) -> Result<FlatGeobufRecordBatchReader<R, Seekable>>;
}

pub struct FlatGeobufRecordBatchReader<R, S> {
    selection: FeatureIter<R, S>,
}

impl<R: Read> FlatGeobufRecordBatchReader<R, NotSeekable> {
    fn process_batch(&mut self) -> Result<Option<RecordBatch>>;
}

impl<R: Read + Seek> FlatGeobufRecordBatchReader<R, Seekable> {
    fn process_batch(&mut self) -> Result<Option<RecordBatch>>;
}
```

So what's happening is that I'm wrapping the `FeatureIter`, so that I can call [`FallibleStreamingIterator::next`](https://docs.rs/flatgeobuf/latest/flatgeobuf/trait.FallibleStreamingIterator.html#method.next) on it, the number of times that we have rows in each record batch.

However in order to call `FeatureIter::next`, I need to define that the bound is either `Seekable` or `NotSeekable`, and it's impossible to do that currently because those marker structs are hidden.