### PR TITLE
TS: Support for XYZ, XYM & XYZM layouts

### DIFF
--- a/src/ts/generic/geometry.ts
+++ b/src/ts/generic/geometry.ts
@@ -117,7 +117,6 @@ export function parseGeometry(geometry: ISimpleGeometry, headerGeomType: Geometr
         type = toGeometryType(geometry.getType());
     }
 
-
     let flatEnds: number[] | undefined;
     if (type === GeometryType.MultiLineString) {
         if (geometry.getFlatCoordinates) flatCoordinates = geometry.getFlatCoordinates();

--- a/src/ts/ol.spec.ts
+++ b/src/ts/ol.spec.ts
@@ -155,7 +155,9 @@ describe('ol module', () => {
         });
 
         it('Polygon ZM', () => {
-            const expected = makeFeatureCollection('POLYGON ZM((30 10 12.1 1, 40 40 4 1, 20 40 4 1, 10 20 0.5 1, 30 10 12 1))');
+            const expected = makeFeatureCollection(
+                'POLYGON ZM((30 10 12.1 1, 40 40 4 1, 20 40 4 1, 10 20 0.5 1, 30 10 12 1))',
+            );
             const actual = deserialize(serialize(expected)) as Feature[];
             expect(g(actual)).to.equal(g(expected));
         });
@@ -180,7 +182,6 @@ describe('ol module', () => {
             const actual = deserialize(serialize(expected)) as Feature[];
             expect(g(actual)).to.equal(g(expected));
         });
-
 
         it('PolygonWithTwoHoles', () => {
             const expected = makeFeatureCollection(`POLYGON ((35 10, 45 45, 15 40, 10 20, 35 10),

--- a/src/ts/ol/geometry.ts
+++ b/src/ts/ol/geometry.ts
@@ -3,13 +3,13 @@ import type { Geometry } from '../flat-geobuf/geometry.js';
 
 import type { ISimpleGeometry } from '../generic/geometry.js';
 
+import type { GeometryLayout } from 'ol/geom/Geometry.js';
 import LineString from 'ol/geom/LineString.js';
 import MultiLineString from 'ol/geom/MultiLineString.js';
 import MultiPoint from 'ol/geom/MultiPoint.js';
 import MultiPolygon from 'ol/geom/MultiPolygon.js';
 import Point from 'ol/geom/Point.js';
 import Polygon from 'ol/geom/Polygon.js';
-import type { GeometryLayout } from 'ol/geom/Geometry.js';
 
 function interleaveZ(flatCoordinates: number[], z: number[]): number[] {
     const newFlatCoordinates = new Array(flatCoordinates.length + z.length);


### PR DESCRIPTION
# Issue

Reading and writing from openlayers only supports 2D coordinates, even though both openlayers and flatgeobuf support other geometry layouts. 

# Solution

This MR add the capabilities to read & write all openlayer layouts using the node library.