### PR TITLE
[rust] Add semver checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,3 +136,14 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('src/rust/Cargo.toml') }}
           restore-keys: ${{ runner.os }}-cargo-
       - run: cd src/rust && cargo test --no-default-features
+
+  rust-semver-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          manifest-path: src/rust/Cargo.toml
+          feature-group: default-features


### PR DESCRIPTION
Simple PR adding the [cargo-semver-checks](https://github.com/obi1kenobi/cargo-semver-checks-action) action to CI along with the tests. This will ensure semver compatibility going forward and remove the guesswork :)

NOTE: I didn't copy the existing rust setup actions, because this action already grabs the latest stable Rust by default internall. I've enabled maintainer edits though in case you want to make any changes.