### PR TITLE
Add static method to AsyncFeatureEnumerator to count the total number of records without allocating features.

### DIFF
--- a/src/net/FlatGeobuf.Tests/NTS/AsyncFeatureEnumeratorTest.cs
+++ b/src/net/FlatGeobuf.Tests/NTS/AsyncFeatureEnumeratorTest.cs
@@ -29,6 +29,16 @@ namespace FlatGeobuf.Tests.NTS
         }
 
         [TestMethod]
+        public async Task TestCountriesCount() {
+            using var fs = File.OpenRead("../../../../../../test/data/countries.fgb");
+            var count = await AsyncFeatureEnumerator.CountAsync(fs);
+            Assert.AreEqual(179, (int)count);
+            Assert.ThrowsException<ObjectDisposedException>(()=> {
+                fs.Position = 0;
+            });
+        }
+
+        [TestMethod]
         public async Task TestCountriesWithNoCRS() {
             var ae = await AsyncFeatureEnumerator.Create(File.OpenRead("../../../../../../test/data/countries_nocrs.fgb"));
             Assert.IsNotNull(ae);
@@ -41,6 +51,12 @@ namespace FlatGeobuf.Tests.NTS
             }
 
             Assert.AreEqual(numFeaturesExpected, numFeaturesRead);
+        }
+
+        [TestMethod]
+        public async Task TestCountriesWithNoCrsCount() {
+            var count = await AsyncFeatureEnumerator.CountAsync(File.OpenRead("../../../../../../test/data/countries_nocrs.fgb"));
+            Assert.AreEqual(179, (int)count);
         }
 
         [TestMethod]
@@ -60,6 +76,11 @@ namespace FlatGeobuf.Tests.NTS
             Assert.AreEqual(179, numRowsRead);
         }
 
+        [TestMethod]
+        public async Task TestCountriesWithNoGeometryCount() {
+            var count = await AsyncFeatureEnumerator.CountAsync(File.OpenRead("../../../../../../test/data/countries_nogeo.fgb"));
+            Assert.AreEqual(179, (int)count);
+        }
         //
 
         [TestMethod]


### PR DESCRIPTION
I would like to be able to get an accurate count of the total number of records in a file, but I also can't guarantee my input files would necessarily all contain geometry. Thus I can't always trust the header FeatureCount. I can get around this by just iterating through the file, but as-is I would have to call MoveNext() and allocate every geometry along the way.

I made this new method a static method since it would be consuming the stream in its entirety. 