### PR TITLE
[ts] Publish generic parseProperties function

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
         "3-yuma-3",
         "Adrien Durand",
         "Ben Kuster",
+        "Benjamin Gerber",
         "Björn Harrtell",
         "bruno-ga",
         "Chenyu Wang",

--- a/src/ts/generic.ts
+++ b/src/ts/generic.ts
@@ -50,4 +50,5 @@ export function deserialize(
     return deserializeFiltered(input, rect as Rect, fromFeature, undefined, nocache, headers);
 }
 
+export { parseProperties } from './generic/feature.js';
 export { serialize } from './generic/featurecollection.js';

--- a/src/ts/generic/feature.ts
+++ b/src/ts/generic/feature.ts
@@ -156,6 +156,11 @@ export function buildFeature(geometry: IParsedGeometry, properties: IProperties,
     return builder.asUint8Array() as Uint8Array;
 }
 
+/**
+ * Parse properties from a FlatGeobuf feature.
+ * @param feature Feature to parse the properties from.
+ * @param columns Column metadata used as property definition.
+ */
 export function parseProperties(feature: Feature, columns?: ColumnMeta[] | null): IProperties {
     const properties: IProperties = {};
     if (!columns || columns.length === 0) return properties;


### PR DESCRIPTION
For issue #448 

Publish `generic/feature.ts parseProperties` function to ease the creation of custom features from generic Features.