### PR TITLE
[java] Improve handling of large number of items

### DIFF
--- a/src/java/src/main/java/org/wololo/flatgeobuf/PackedRTree.java
+++ b/src/java/src/main/java/org/wololo/flatgeobuf/PackedRTree.java
@@ -188,17 +188,18 @@ public class PackedRTree {
         }
     }
 
-    public static long calcSize(long numItems, int nodeSize) {
+    public static long calcSize(int numItems, int nodeSize) {
         if (nodeSize < 2)
             throw new RuntimeException("Node size must be at least 2");
         if (numItems == 0)
             throw new RuntimeException("Number of items must be greater than 0");
         int nodeSizeMin = Math.min(Math.max(nodeSize, 2), 65535);
+        // NOTE: not relevant as current impl. is already limited to int
         // limit so that resulting size in bytes can be represented by ulong
-        if (numItems > 1L << 56)
-            throw new IndexOutOfBoundsException("Number of items must be less than 2^56");
-        long n = numItems;
-        long numNodes = n;
+        //if (numItems > 1L << 56)
+        //    throw new IndexOutOfBoundsException("Number of items must be less than 2^56");
+        int n = numItems;
+        int numNodes = n;
         do {
             n = (n + nodeSizeMin - 1) / nodeSizeMin;
             numNodes += n;


### PR DESCRIPTION
Bad math caused limit check to limit to 16.7 million items, this raises it to signed integer limit (2.1 billion).

Also buffer write output to converve memory.

ref https://github.com/flatgeobuf/flatgeobuf/issues/450