### PR TITLE
[ts] Use fully specified modules paths

### DIFF
--- a/src/ts/ol/feature.ts
+++ b/src/ts/ol/feature.ts
@@ -1,5 +1,5 @@
 import OlFeature from 'ol/Feature.js';
-import { transformGeometryWithOptions } from 'ol/format/Feature';
+import { transformGeometryWithOptions } from 'ol/format/Feature.js';
 import RenderFeature, { type Type } from 'ol/render/Feature.js';
 import type { Feature } from '../flat-geobuf/feature.js';
 import {

--- a/src/ts/ol/featurecollection.ts
+++ b/src/ts/ol/featurecollection.ts
@@ -1,6 +1,6 @@
 import type { Extent } from 'ol/extent.js';
 import Feature from 'ol/Feature.js';
-import { transformExtent } from 'ol/proj';
+import { transformExtent } from 'ol/proj.js';
 import type RenderFeature from 'ol/render/Feature.js';
 import type { IFeature } from '../generic/feature.js';
 import {


### PR DESCRIPTION
Add the `*.js` extension to be sure the ol dependencies will be found.

```
rspack build --config assets/webpack.prod.js

ERROR in ./node_modules/flatgeobuf/lib/mjs/ol/feature.js 1:29-94
  × Module not found: Can't resolve 'ol/format/Feature' in '/home/dhont/public_html/lizmap_master/node_modules/flatgeobuf/lib/mjs/ol'
   ╭─[1:29]
 1 │ import e from"ol/Feature.js";import{transformGeometryWithOptions as t}from"ol/format/Feature";import r from"ol/render/Feature.js";import{fromFeature as o}from"../generic/feature.js";import{createGeometry as n}from"./geometry.js";export function getFromFeatureFn(i=e,m="EPSG:4326",a){let l;return l=i===r?function(e,o,n){let i=o?.getType()==="MultiPolygon"?"Polygon":o?.getType();if("GeometryCollection"===i||"Circle"===i)throw Error(`Unsupported geometry type: ${i}`);let l=o?.getFlatCoordinates?.(),f=o?.getLayout?.().length;if(!l||!f)throw Error(`Geometry without coordinates: ${o}`);return t(new r(i,l,[l.length],f,n||{},e).enableSimplifyTransformed(),!1,{dataProjection:m,featureProjection:a})}:function(t,r,o){let n=new e(r);return a&&m!==a&&n.getGeometry()?.transform(m,a),n.setId(t),o&&n.setProperties&&n.setProperties(o),n},(e,t,r)=>o(e,t,r,n,l)}
   ·                              ─────────────────────────────────────────────────────────────────
 2 │ //# sourceMappingURL=feature.js.map
   ╰────
  help: Did you mean '/home/dhont/public_html/lizmap_master/node_modules/ol/format/Feature.js'?

        The request 'ol/format/Feature' failed to resolve only because it was resolved as fully specified,
        probably because the origin is strict EcmaScript Module,
        e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"'.

        The extension in the request is mandatory for it to be fully specified.
        Add the extension to the request.

ERROR in ./node_modules/flatgeobuf/lib/mjs/ol/featurecollection.js 1:29-71
  × Module not found: Can't resolve 'ol/proj' in '/home/dhont/public_html/lizmap_master/node_modules/flatgeobuf/lib/mjs/ol'
   ╭─[1:29]
 1 │ import e from"ol/Feature.js";import{transformExtent as t}from"ol/proj";import{deserialize as o,deserializeFiltered as i,deserializeStream as r,serialize as s}from"../generic/featurecollection.js";import{getFromFeatureFn as a}from"./feature.js";export class FeatureCollection{options;constructor(t){this.options={featureClass:e,dataProjection:"EPSG:4326",headers:{},nocache:!1,...t}}getHeaders(){return this.options.headers}setOptions(e){this.options={...this.options,...e}}getRect(e){let[o,i,r,s]=this.options.featureProjection&&this.options.dataProjection!==this.options.featureProjection?t(e,this.options.dataProjection,this.options.featureProjection):e;return{minX:o,minY:i,maxX:r,maxY:s}}serialize(e){return s(e)}async *deserialize(e,t){yield*o(e,this.getFromFeatureFn(),t,this.options.headerMetaFn)}deserializeStream(e){return r(e,this.getFromFeatureFn(),this.options.headerMetaFn)}deserializeFiltered(e,t){return i(e,t,this.getFromFeatureFn(),this.options.headerMetaFn,this.options.nocache,this.options.headers)}getFromFeatureFn(){return a(this.options.featureClass,this.options.dataProjection,this.options.featureProjection)}}
   ·                              ──────────────────────────────────────────
 2 │ //# sourceMappingURL=featurecollection.js.map
   ╰────
  help: Did you mean '/home/dhont/public_html/lizmap_master/node_modules/ol/proj.js'?

        The request 'ol/proj' failed to resolve only because it was resolved as fully specified,
        probably because the origin is strict EcmaScript Module,
        e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"'.

        The extension in the request is mandatory for it to be fully specified.
        Add the extension to the request.

Rspack compiled with 2 errors in 2.68 s
```