### PR TITLE
ts - Add a new Deserializer class

### DIFF
--- a/src/ts/deserializer.ts
+++ b/src/ts/deserializer.ts
@@ -1,0 +1,88 @@
+import type { HeaderMetaFn } from "./generic";
+import type { IFeature } from "./generic/feature";
+import {
+    type FromFeatureFn,
+    deserialize as genericDeserialize,
+    deserializeFiltered as genericDeserializeFiltered,
+    deserializeStream as genericDeserializeStream,
+} from './generic/featurecollection.js';
+import type { Rect } from './packedrtree.js';
+import { getFromFeatureFn } from './ol/feature.js';
+import { transformExtent } from "ol/proj.js";
+import type { Extent } from "ol/extent.js";
+
+export interface DeserializerOptions {
+    /** Data projection. Defaults to EPSG:4326 */
+    dataProjection: string;
+    /** Callback that will receive header metadata when available. Defaults to undefined. */
+    headerMetaFn?: HeaderMetaFn;
+    /** Header to request the file from. Defaults to an empty object. */
+    headers: HeadersInit;
+    /** Disable caching of the file. Defaults to false. */
+    nocache: boolean;
+    /**
+     * Feature class to be used when creating features.
+     * If performance is the primary concern and features are not going to be
+     * modified, consider using RenderFeature (Circle and GeometryCollection are
+     * not supported. As coordinates are flattened, multi geometries and polygons
+     * with holes are not well rendered).
+     * Default to false (use Feature and not RenderFeature).
+     */
+    renderFeature: boolean;
+}
+
+export class Deserializer {
+    private options: DeserializerOptions;
+
+    constructor(options?: Partial<DeserializerOptions>) {
+        this.options = {
+            renderFeature: false,
+            dataProjection: 'EPSG:4326',
+            headers: {},
+            nocache: false,
+            ...options,
+        };
+    }
+
+    getHeaders(): HeadersInit {
+        return this.options.headers;
+    }
+
+    setOptions(options: Partial<DeserializerOptions>): void {
+        this.options = {
+            ...this.options,
+            ...options,
+        };
+    }
+
+    async *deserialize(bytes: Uint8Array, rect?: Rect, featureProjection?: string): AsyncGenerator<IFeature> {
+        yield* genericDeserialize(bytes, this.getFromFeatureFn(featureProjection), rect, this.options.headerMetaFn);
+    }
+
+    deserializeStream(stream: ReadableStream, featureProjection?: string): AsyncGenerator<IFeature> {
+        return genericDeserializeStream(stream, this.getFromFeatureFn(featureProjection), this.options.headerMetaFn);
+    }
+
+    deserializeFiltered(url: string, rect: Rect, featureProjection?: string): AsyncGenerator<IFeature> {
+        return genericDeserializeFiltered(
+            url,
+            rect,
+            this.getFromFeatureFn(featureProjection),
+            this.options.headerMetaFn,
+            this.options.nocache,
+            this.options.headers,
+        );
+    }
+
+    getRect(extent: Extent, featureProjection?: string): Rect {
+        const [minX, minY, maxX, maxY] =
+            featureProjection && this.options.dataProjection !== featureProjection
+                ? transformExtent(extent, featureProjection, this.options.dataProjection)
+                : extent;
+        return { minX, minY, maxX, maxY };
+    }
+
+    private getFromFeatureFn(featureProjection?: string): FromFeatureFn {
+        return getFromFeatureFn(this.options.renderFeature, this.options.dataProjection, featureProjection);
+    }
+}

--- a/src/ts/deserializer.ts
+++ b/src/ts/deserializer.ts
@@ -1,15 +1,15 @@
-import type { HeaderMetaFn } from "./generic";
-import type { IFeature } from "./generic/feature";
+import type { Extent } from 'ol/extent.js';
+import { transformExtent } from 'ol/proj.js';
+import type { HeaderMetaFn } from './generic';
+import type { IFeature } from './generic/feature';
 import {
     type FromFeatureFn,
     deserialize as genericDeserialize,
     deserializeFiltered as genericDeserializeFiltered,
     deserializeStream as genericDeserializeStream,
 } from './generic/featurecollection.js';
-import type { Rect } from './packedrtree.js';
 import { getFromFeatureFn } from './ol/feature.js';
-import { transformExtent } from "ol/proj.js";
-import type { Extent } from "ol/extent.js";
+import type { Rect } from './packedrtree.js';
 
 export interface DeserializerOptions {
     /** Data projection. Defaults to EPSG:4326 */

--- a/src/ts/ol.spec.ts
+++ b/src/ts/ol.spec.ts
@@ -8,7 +8,7 @@ import type SimpleGeometry from 'ol/geom/SimpleGeometry.js';
 import { transform } from 'ol/proj';
 import type RenderFeature from 'ol/render/Feature.js';
 import { describe, expect, it } from 'vitest';
-import { deserialize, serialize } from './ol.js';
+import { Deserializer, deserialize, serialize } from './ol.js';
 import { arrayToStream, takeAsync } from './streams/utils.js';
 
 const format = new WKT();
@@ -450,11 +450,13 @@ describe('ol module', () => {
     });
 
     describe('Geometry roundtrips with RenderFeatures', () => {
+        const deserializer = new Deserializer({ renderFeature: true });
+
         it('Point', async () => {
             const expected = makeFeatureCollection('POINT(1.2 -2.1)');
             const s = serialize(expected);
             const actual = (await takeAsync<FeatureLike>(
-                deserialize(s, undefined, undefined, undefined, undefined, true),
+                deserialize(s, undefined, undefined, deserializer),
             )) as RenderFeature[];
             expect(actual[0].getType()).toEqual('Point');
             expect(actual[0].getFlatCoordinates()).toEqual([1.2, -2.1]);
@@ -463,7 +465,7 @@ describe('ol module', () => {
         it('MultiPoint', async () => {
             const expected = makeFeatureCollection('MULTIPOINT(10 40, 40 30, 20 20, 30 10)');
             const actual = (await takeAsync<FeatureLike>(
-                deserialize(serialize(expected), undefined, undefined, undefined, undefined, true),
+                deserialize(serialize(expected), undefined, undefined, deserializer),
             )) as RenderFeature[];
             expect(actual[0].getType()).toEqual('MultiPoint');
             expect(actual[0].getFlatCoordinates()).toEqual([10, 40, 40, 30, 20, 20, 30, 10]);
@@ -472,7 +474,7 @@ describe('ol module', () => {
         it('LineString', async () => {
             const expected = makeFeatureCollection('LINESTRING(1.2 -2.1, 2.4 -4.8)');
             const actual = (await takeAsync<FeatureLike>(
-                deserialize(serialize(expected), undefined, undefined, undefined, undefined, true),
+                deserialize(serialize(expected), undefined, undefined, deserializer),
             )) as RenderFeature[];
             expect(actual[0].getType()).toEqual('LineString');
             expect(actual[0].getFlatCoordinates()).toEqual([1.2, -2.1, 2.4, -4.8]);
@@ -481,7 +483,7 @@ describe('ol module', () => {
         it('Polygon', async () => {
             const expected = makeFeatureCollection('POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))');
             const actual = (await takeAsync<FeatureLike>(
-                deserialize(serialize(expected), undefined, undefined, undefined, undefined, true),
+                deserialize(serialize(expected), undefined, undefined, deserializer),
             )) as RenderFeature[];
             expect(actual[0].getType()).toEqual('Polygon');
             expect(actual[0].getFlatCoordinates()).toEqual([30, 10, 40, 40, 20, 40, 10, 20, 30, 10]);
@@ -495,8 +497,9 @@ describe('ol module', () => {
 
             it('Point to Feature', async () => {
                 const s = serialize(points);
+                const deserializer = new Deserializer({ dataProjection: 'EPSG:4326' });
                 const actual = (await takeAsync<FeatureLike>(
-                    deserialize(s, undefined, undefined, undefined, undefined, undefined, 'EPSG:4326', 'EPSG:3857'),
+                    deserialize(s, undefined, 'EPSG:3857', deserializer),
                 )) as Feature[];
                 const actualGeometry = actual[0].getGeometry() as Point;
                 expect(actualGeometry.getFlatCoordinates()).toEqual(expected);
@@ -504,8 +507,9 @@ describe('ol module', () => {
 
             it('Point to RenderFeature', async () => {
                 const s = serialize(points);
+                const deserializer = new Deserializer({ dataProjection: 'EPSG:4326', renderFeature: true });
                 const actual = (await takeAsync<FeatureLike>(
-                    deserialize(s, undefined, undefined, undefined, undefined, true, 'EPSG:4326', 'EPSG:3857'),
+                    deserialize(s, undefined, 'EPSG:3857', deserializer),
                 )) as RenderFeature[];
                 expect(actual[0].getFlatCoordinates()).toEqual(expected);
             });

--- a/src/ts/ol.ts
+++ b/src/ts/ol.ts
@@ -4,16 +4,14 @@ import type { FeatureLoader } from 'ol/featureloader.js';
 import { all } from 'ol/loadingstrategy.js';
 import type VectorSource from 'ol/source/Vector.js';
 import type { LoadingStrategy } from 'ol/source/Vector.js';
+import type VectorTileSource from 'ol/source/VectorTile.js';
 import type { LoadFunction } from 'ol/Tile.js';
 import type { TileCoord } from 'ol/tilecoord.js';
 import type VectorTile from 'ol/VectorTile.js';
+import { Deserializer, type DeserializerOptions } from './deserializer';
 import type { IFeature } from './generic/feature.js';
-import {
-    serialize as genericSerialize,
-} from './generic/featurecollection.js';
+import { serialize as genericSerialize } from './generic/featurecollection.js';
 import type { Rect } from './packedrtree.js';
-import { Deserializer, type DeserializerOptions } from "./deserializer";
-import type VectorTileSource from "ol/source/VectorTile.js";
 
 export { Deserializer };
 export type { DeserializerOptions };
@@ -29,16 +27,16 @@ export function serialize(features: Feature[]): Uint8Array {
 
 /**
  * Deserialize FlatGeobuf into OpenLayers Features
- * @param deserializer Deserializer instance
  * @param input Input byte array, stream or string
  * @param rect Filter rectangle
  * @param featureProjection Feature projection. Defaults to EPSG:4326
+ * @param deserializer Deserializer instance
  */
 export function deserialize(
-    deserializer: Deserializer,
     input: Uint8Array | ReadableStream | string,
     rect?: Rect,
     featureProjection = 'EPSG:4326',
+    deserializer: Deserializer = new Deserializer(),
 ): AsyncGenerator<FeatureLike> {
     if (input instanceof Uint8Array)
         return deserializer.deserialize(input, rect, featureProjection) as AsyncGenerator<FeatureLike>;
@@ -52,17 +50,17 @@ export function deserialize(
 /**
  * Intended to be used with VectorSource and setLoader to set up
  * a single file FlatGeobuf as a source.
- * @param deserializer
  * @param source
  * @param url
+ * @param deserializer
  * @param strategy
  * @param clear
  * @returns
  */
 export function createLoader(
-    deserializer: Deserializer,
     source: VectorSource<FeatureLike>,
     url: string,
+    deserializer: Deserializer = new Deserializer(),
     strategy: LoadingStrategy = all,
     clear = false,
 ): FeatureLoader<FeatureLike> {
@@ -73,15 +71,10 @@ export function createLoader(
             let it: AsyncGenerator<FeatureLike> | undefined;
             if (strategy === all) {
                 const response = await fetch(url, { headers: deserializer.getHeaders() });
-                it = deserialize(
-                    deserializer,
-                    response.body as ReadableStream,
-                    undefined,
-                    projection.getCode(),
-                );
+                it = deserialize(response.body as ReadableStream, undefined, projection.getCode(), deserializer);
             } else {
                 const rect = deserializer.getRect(extent);
-                it = deserialize(deserializer, url, rect, projection.getCode());
+                it = deserialize(url, rect, projection.getCode(), deserializer);
             }
             for await (const feature of it) {
                 features.push(feature);
@@ -105,15 +98,15 @@ export const tileUrlFunction = (tileCoord: TileCoord) => JSON.stringify(tileCoor
 /**
  * Intended to be used with VectorTileSource and setTileLoadFunction to set up
  * a single file FlatGeobuf as a source.
- * @param deserializer
  * @param source
  * @param url
+ * @param deserializer
  * @returns
  */
 export function createTileLoadFunction(
-    deserializer: Deserializer,
     source: VectorTileSource,
     url: string,
+    deserializer: Deserializer = new Deserializer(),
 ) {
     const projection = source.getProjection();
     const code = projection?.getCode() ?? 'EPSG:3857';
@@ -121,7 +114,7 @@ export function createTileLoadFunction(
         const vectorTile = tile as VectorTile<FeatureLike>;
         const loader: FeatureLoader = async (extent) => {
             const rect = deserializer.getRect(extent, code);
-            const it = deserialize(deserializer, url, rect, code);
+            const it = deserialize(url, rect, code, deserializer);
             const features: FeatureLike[] = [];
             for await (const feature of it) features.push(feature);
             vectorTile.setFeatures(features);

--- a/src/ts/ol.ts
+++ b/src/ts/ol.ts
@@ -1,25 +1,22 @@
-import type { Extent } from 'ol/extent.js';
 import type Feature from 'ol/Feature.js';
 import type { FeatureLike } from 'ol/Feature.js';
 import type { FeatureLoader } from 'ol/featureloader.js';
 import { all } from 'ol/loadingstrategy.js';
-import { transformExtent } from 'ol/proj.js';
 import type VectorSource from 'ol/source/Vector.js';
 import type { LoadingStrategy } from 'ol/source/Vector.js';
-import type VectorTileSource from 'ol/source/VectorTile.js';
 import type { LoadFunction } from 'ol/Tile.js';
 import type { TileCoord } from 'ol/tilecoord.js';
 import type VectorTile from 'ol/VectorTile.js';
 import type { IFeature } from './generic/feature.js';
 import {
-    deserialize as genericDeserialize,
-    deserializeFiltered as genericDeserializeFiltered,
-    deserializeStream as genericDeserializeStream,
     serialize as genericSerialize,
 } from './generic/featurecollection.js';
-import type { HeaderMetaFn } from './generic.js';
-import { getFromFeatureFn } from './ol/feature.js';
 import type { Rect } from './packedrtree.js';
+import { Deserializer, type DeserializerOptions } from "./deserializer";
+import type VectorTileSource from "ol/source/VectorTile.js";
+
+export { Deserializer };
+export type { DeserializerOptions };
 
 /**
  * Serialize OpenLayers Features to FlatGeobuf
@@ -32,46 +29,30 @@ export function serialize(features: Feature[]): Uint8Array {
 
 /**
  * Deserialize FlatGeobuf into OpenLayers Features
+ * @param deserializer Deserializer instance
  * @param input Input byte array, stream or string
  * @param rect Filter rectangle
+ * @param featureProjection Feature projection. Defaults to EPSG:4326
  */
 export function deserialize(
+    deserializer: Deserializer,
     input: Uint8Array | ReadableStream | string,
     rect?: Rect,
-    headerMetaFn?: HeaderMetaFn,
-    nocache = false,
-    headers: HeadersInit = {},
-    renderFeature = false,
-    dataProjection = 'EPSG:4326',
     featureProjection = 'EPSG:4326',
 ): AsyncGenerator<FeatureLike> {
-    const fromFeature = getFromFeatureFn(renderFeature, dataProjection, featureProjection);
     if (input instanceof Uint8Array)
-        return genericDeserialize(input, fromFeature, rect, headerMetaFn) as AsyncGenerator<FeatureLike>;
+        return deserializer.deserialize(input, rect, featureProjection) as AsyncGenerator<FeatureLike>;
     if (input instanceof ReadableStream)
-        return genericDeserializeStream(input, fromFeature, headerMetaFn) as AsyncGenerator<FeatureLike>;
+        return deserializer.deserializeStream(input, featureProjection) as AsyncGenerator<FeatureLike>;
     if (typeof input === 'string' && rect)
-        return genericDeserializeFiltered(
-            input,
-            rect,
-            fromFeature,
-            headerMetaFn,
-            nocache,
-            headers,
-        ) as AsyncGenerator<FeatureLike>;
+        return deserializer.deserializeFiltered(input, rect, featureProjection) as AsyncGenerator<FeatureLike>;
     throw new Error('Invalid input type or missing rect for URL input');
-}
-
-function extentToRect(extent: Extent, source?: string, destination?: string): Rect {
-    const [minX, minY, maxX, maxY] =
-        source && destination && source !== destination ? transformExtent(extent, source, destination) : extent;
-    const rect = { minX, minY, maxX, maxY };
-    return rect;
 }
 
 /**
  * Intended to be used with VectorSource and setLoader to set up
  * a single file FlatGeobuf as a source.
+ * @param deserializer
  * @param source
  * @param url
  * @param strategy
@@ -79,35 +60,28 @@ function extentToRect(extent: Extent, source?: string, destination?: string): Re
  * @returns
  */
 export function createLoader(
+    deserializer: Deserializer,
     source: VectorSource<FeatureLike>,
     url: string,
-    srs = 'EPSG:4326',
     strategy: LoadingStrategy = all,
     clear = false,
-    headers: HeadersInit = {},
-    renderFeature = false,
 ): FeatureLoader<FeatureLike> {
     return async (extent, _resolution, projection, success, failure) => {
         try {
             if (clear) source.clear();
-            const code = projection.getCode();
             const features: FeatureLike[] = [];
             let it: AsyncGenerator<FeatureLike> | undefined;
             if (strategy === all) {
-                const response = await fetch(url, { headers });
+                const response = await fetch(url, { headers: deserializer.getHeaders() });
                 it = deserialize(
+                    deserializer,
                     response.body as ReadableStream,
                     undefined,
-                    undefined,
-                    false,
-                    headers,
-                    renderFeature,
-                    srs,
-                    code,
+                    projection.getCode(),
                 );
             } else {
-                const rect = extentToRect(extent, code, srs);
-                it = deserialize(url, rect, undefined, false, headers, renderFeature, srs, code);
+                const rect = deserializer.getRect(extent);
+                it = deserialize(deserializer, url, rect, projection.getCode());
             }
             for await (const feature of it) {
                 features.push(feature);
@@ -131,23 +105,23 @@ export const tileUrlFunction = (tileCoord: TileCoord) => JSON.stringify(tileCoor
 /**
  * Intended to be used with VectorTileSource and setTileLoadFunction to set up
  * a single file FlatGeobuf as a source.
+ * @param deserializer
+ * @param source
  * @param url
  * @returns
  */
 export function createTileLoadFunction(
+    deserializer: Deserializer,
     source: VectorTileSource,
     url: string,
-    srs = 'EPSG:4326',
-    headers: HeadersInit = {},
-    renderFeature = false,
 ) {
     const projection = source.getProjection();
     const code = projection?.getCode() ?? 'EPSG:3857';
     const tileLoadFunction: LoadFunction = (tile) => {
         const vectorTile = tile as VectorTile<FeatureLike>;
         const loader: FeatureLoader = async (extent) => {
-            const rect = extentToRect(extent, code, srs);
-            const it = deserialize(url, rect, undefined, false, headers, renderFeature, srs, code);
+            const rect = deserializer.getRect(extent, code);
+            const it = deserialize(deserializer, url, rect, code);
             const features: FeatureLike[] = [];
             for await (const feature of it) features.push(feature);
             vectorTile.setFeatures(features);

--- a/vite/src/ol-tile.ts
+++ b/vite/src/ol-tile.ts
@@ -5,10 +5,12 @@ import OSM from 'ol/source/OSM.js';
 import VectorTileSource from 'ol/source/VectorTile.js';
 import View from 'ol/View.js';
 import { createTileLoadFunction, tileUrlFunction } from '../../src/ts/ol';
+import { Deserializer } from "../../src/ts/deserializer";
 
 const url = '/data/countries.fgb';
 const source = new VectorTileSource({ tileUrlFunction });
-source.setTileLoadFunction(createTileLoadFunction(source, url));
+const deserializer = new Deserializer()
+source.setTileLoadFunction(createTileLoadFunction(deserializer, source, url));
 
 new Map({
     layers: [new TileLayer({ source: new OSM() }), new VectorTileLayer({ source })],

--- a/vite/src/ol-tile.ts
+++ b/vite/src/ol-tile.ts
@@ -5,12 +5,10 @@ import OSM from 'ol/source/OSM.js';
 import VectorTileSource from 'ol/source/VectorTile.js';
 import View from 'ol/View.js';
 import { createTileLoadFunction, tileUrlFunction } from '../../src/ts/ol';
-import { Deserializer } from "../../src/ts/deserializer";
 
 const url = '/data/countries.fgb';
 const source = new VectorTileSource({ tileUrlFunction });
-const deserializer = new Deserializer()
-source.setTileLoadFunction(createTileLoadFunction(deserializer, source, url));
+source.setTileLoadFunction(createTileLoadFunction(source, url));
 
 new Map({
     layers: [new TileLayer({ source: new OSM() }), new VectorTileLayer({ source })],

--- a/vite/src/ol.ts
+++ b/vite/src/ol.ts
@@ -2,15 +2,17 @@ import TileLayer from 'ol/layer/Tile.js';
 import VectorLayer from 'ol/layer/Vector.js';
 import { bbox } from 'ol/loadingstrategy';
 import Map from 'ol/Map.js';
-// import RenderFeature from "ol/render/Feature.js";
 import OSM from 'ol/source/OSM.js';
 import VectorSource from 'ol/source/Vector.js';
 import View from 'ol/View.js';
 import { createLoader } from '../../src/ts/ol';
-
+import { Deserializer } from "../../src/ts/deserializer";
 const url = '/data/countries.fgb';
 const source = new VectorSource({ strategy: bbox });
-source.setLoader(createLoader(source, url));
+const deserializer = new Deserializer({
+    // renderFeature: true,
+})
+source.setLoader(createLoader(deserializer, source, url));
 
 new Map({
     layers: [new TileLayer({ source: new OSM() }), new VectorLayer({ source })],

--- a/vite/src/ol.ts
+++ b/vite/src/ol.ts
@@ -6,13 +6,19 @@ import OSM from 'ol/source/OSM.js';
 import VectorSource from 'ol/source/Vector.js';
 import View from 'ol/View.js';
 import { createLoader } from '../../src/ts/ol';
-import { Deserializer } from "../../src/ts/deserializer";
+
 const url = '/data/countries.fgb';
 const source = new VectorSource({ strategy: bbox });
-const deserializer = new Deserializer({
-    // renderFeature: true,
-})
-source.setLoader(createLoader(deserializer, source, url));
+
+//// To test renderFeatures:
+// import { Deserializer } from "../../src/ts/deserializer";
+//
+// const deserializer = new Deserializer({
+//     renderFeature: true,
+// })
+// source.setLoader(createLoader(source, url, deserializer));
+
+source.setLoader(createLoader(source, url));
 
 new Map({
     layers: [new TileLayer({ source: new OSM() }), new VectorLayer({ source })],


### PR DESCRIPTION
Proposition for #490 

Here's my proposition to introduce a new `Deserializer` class, and related options.
In my opinion, this is great to add at this point, because this would provide more flexibility to the code.

1. This is a breaking change.
   - But the only change for the users is probably to provide an instance of the `Deserializer` and remove some other parameters.
1. We could also add a `featureProjection` option to the  `Deserializer`  class to not provide every time the wanted projection (search for `featureProjection` in this PR). But this leads to have to set the projection first, and to not rely anymore on the dynamic projection given from `ol`, in the `createLoader` method.
   - I've not used this option in my  code to not make too much changes, but I think this would be a nice to have.
1. I've not adapted the tests yet, but the vite examples are working well.

In the vite examples, it makes not a lot of differences, but as soon as you work with options in a real cases, it, IMO, really helps to have less code and a better flexibility.

So, what are you thinking about it ?