### PR TITLE
ts - Add a new DeserializerOptions interface

### DIFF
--- a/src/ts/deserializerOptions.ts
+++ b/src/ts/deserializerOptions.ts
@@ -1,0 +1,22 @@
+import type { HeaderMetaFn } from './generic';
+
+export interface DeserializerOptions {
+    /** Data projection (source). */
+    dataProjection?: string;
+    /** Features projection (destination). */
+    featureProjection?: string;
+    /** Callback that will receive header metadata when available. */
+    headerMetaFn?: HeaderMetaFn;
+    /** Header to request the file from. */
+    headers?: HeadersInit;
+    /** Disable caching of the file. */
+    nocache?: boolean;
+    /**
+     * Feature class to be used when creating features.
+     * If performance is the primary concern and features are not going to be
+     * modified, consider using RenderFeature (Circle and GeometryCollection are
+     * not supported. As coordinates are flattened, multi geometries and polygons
+     * with holes are not well rendered).
+     */
+    renderFeature?: boolean;
+}

--- a/src/ts/ol.spec.ts
+++ b/src/ts/ol.spec.ts
@@ -8,7 +8,7 @@ import type SimpleGeometry from 'ol/geom/SimpleGeometry.js';
 import { transform } from 'ol/proj';
 import type RenderFeature from 'ol/render/Feature.js';
 import { describe, expect, it } from 'vitest';
-import { deserialize, serialize } from './ol.js';
+import { type DeserializerOptions, deserialize, serialize } from './ol.js';
 import { arrayToStream, takeAsync } from './streams/utils.js';
 
 const format = new WKT();
@@ -450,11 +450,15 @@ describe('ol module', () => {
     });
 
     describe('Geometry roundtrips with RenderFeatures', () => {
+        const deserializerOptions: DeserializerOptions = {
+            renderFeature: true,
+        };
+
         it('Point', async () => {
             const expected = makeFeatureCollection('POINT(1.2 -2.1)');
             const s = serialize(expected);
             const actual = (await takeAsync<FeatureLike>(
-                deserialize(s, undefined, undefined, undefined, undefined, true),
+                deserialize(s, undefined, deserializerOptions),
             )) as RenderFeature[];
             expect(actual[0].getType()).toEqual('Point');
             expect(actual[0].getFlatCoordinates()).toEqual([1.2, -2.1]);
@@ -463,7 +467,7 @@ describe('ol module', () => {
         it('MultiPoint', async () => {
             const expected = makeFeatureCollection('MULTIPOINT(10 40, 40 30, 20 20, 30 10)');
             const actual = (await takeAsync<FeatureLike>(
-                deserialize(serialize(expected), undefined, undefined, undefined, undefined, true),
+                deserialize(serialize(expected), undefined, deserializerOptions),
             )) as RenderFeature[];
             expect(actual[0].getType()).toEqual('MultiPoint');
             expect(actual[0].getFlatCoordinates()).toEqual([10, 40, 40, 30, 20, 20, 30, 10]);
@@ -472,7 +476,7 @@ describe('ol module', () => {
         it('LineString', async () => {
             const expected = makeFeatureCollection('LINESTRING(1.2 -2.1, 2.4 -4.8)');
             const actual = (await takeAsync<FeatureLike>(
-                deserialize(serialize(expected), undefined, undefined, undefined, undefined, true),
+                deserialize(serialize(expected), undefined, deserializerOptions),
             )) as RenderFeature[];
             expect(actual[0].getType()).toEqual('LineString');
             expect(actual[0].getFlatCoordinates()).toEqual([1.2, -2.1, 2.4, -4.8]);
@@ -481,7 +485,7 @@ describe('ol module', () => {
         it('Polygon', async () => {
             const expected = makeFeatureCollection('POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))');
             const actual = (await takeAsync<FeatureLike>(
-                deserialize(serialize(expected), undefined, undefined, undefined, undefined, true),
+                deserialize(serialize(expected), undefined, deserializerOptions),
             )) as RenderFeature[];
             expect(actual[0].getType()).toEqual('Polygon');
             expect(actual[0].getFlatCoordinates()).toEqual([30, 10, 40, 40, 20, 40, 10, 20, 30, 10]);
@@ -496,7 +500,7 @@ describe('ol module', () => {
             it('Point to Feature', async () => {
                 const s = serialize(points);
                 const actual = (await takeAsync<FeatureLike>(
-                    deserialize(s, undefined, undefined, undefined, undefined, undefined, 'EPSG:4326', 'EPSG:3857'),
+                    deserialize(s, undefined, { featureProjection: 'EPSG:3857' }),
                 )) as Feature[];
                 const actualGeometry = actual[0].getGeometry() as Point;
                 expect(actualGeometry.getFlatCoordinates()).toEqual(expected);
@@ -505,7 +509,7 @@ describe('ol module', () => {
             it('Point to RenderFeature', async () => {
                 const s = serialize(points);
                 const actual = (await takeAsync<FeatureLike>(
-                    deserialize(s, undefined, undefined, undefined, undefined, true, 'EPSG:4326', 'EPSG:3857'),
+                    deserialize(s, undefined, { renderFeature: true, featureProjection: 'EPSG:3857' }),
                 )) as RenderFeature[];
                 expect(actual[0].getFlatCoordinates()).toEqual(expected);
             });

--- a/src/ts/ol.ts
+++ b/src/ts/ol.ts
@@ -10,6 +10,7 @@ import type VectorTileSource from 'ol/source/VectorTile.js';
 import type { LoadFunction } from 'ol/Tile.js';
 import type { TileCoord } from 'ol/tilecoord.js';
 import type VectorTile from 'ol/VectorTile.js';
+import type { DeserializerOptions } from './deserializerOptions';
 import type { IFeature } from './generic/feature.js';
 import {
     deserialize as genericDeserialize,
@@ -17,9 +18,10 @@ import {
     deserializeStream as genericDeserializeStream,
     serialize as genericSerialize,
 } from './generic/featurecollection.js';
-import type { HeaderMetaFn } from './generic.js';
 import { getFromFeatureFn } from './ol/feature.js';
 import type { Rect } from './packedrtree.js';
+
+export type { DeserializerOptions };
 
 /**
  * Serialize OpenLayers Features to FlatGeobuf
@@ -34,30 +36,39 @@ export function serialize(features: Feature[]): Uint8Array {
  * Deserialize FlatGeobuf into OpenLayers Features
  * @param input Input byte array, stream or string
  * @param rect Filter rectangle
+ * @param deserializerOptions Deserializer options
  */
 export function deserialize(
     input: Uint8Array | ReadableStream | string,
     rect?: Rect,
-    headerMetaFn?: HeaderMetaFn,
-    nocache = false,
-    headers: HeadersInit = {},
-    renderFeature = false,
-    dataProjection = 'EPSG:4326',
-    featureProjection = 'EPSG:4326',
+    deserializerOptions: DeserializerOptions = {},
 ): AsyncGenerator<FeatureLike> {
-    const fromFeature = getFromFeatureFn(renderFeature, dataProjection, featureProjection);
+    const fromFeature = getFromFeatureFn(
+        deserializerOptions.renderFeature ?? false,
+        deserializerOptions.dataProjection,
+        deserializerOptions.featureProjection,
+    );
     if (input instanceof Uint8Array)
-        return genericDeserialize(input, fromFeature, rect, headerMetaFn) as AsyncGenerator<FeatureLike>;
+        return genericDeserialize(
+            input,
+            fromFeature,
+            rect,
+            deserializerOptions.headerMetaFn,
+        ) as AsyncGenerator<FeatureLike>;
     if (input instanceof ReadableStream)
-        return genericDeserializeStream(input, fromFeature, headerMetaFn) as AsyncGenerator<FeatureLike>;
+        return genericDeserializeStream(
+            input,
+            fromFeature,
+            deserializerOptions.headerMetaFn,
+        ) as AsyncGenerator<FeatureLike>;
     if (typeof input === 'string' && rect)
         return genericDeserializeFiltered(
             input,
             rect,
             fromFeature,
-            headerMetaFn,
-            nocache,
-            headers,
+            deserializerOptions.headerMetaFn,
+            deserializerOptions.nocache,
+            deserializerOptions.headers,
         ) as AsyncGenerator<FeatureLike>;
     throw new Error('Invalid input type or missing rect for URL input');
 }
@@ -76,38 +87,33 @@ function extentToRect(extent: Extent, source?: string, destination?: string): Re
  * @param url
  * @param strategy
  * @param clear
+ * @param deserializerOptions
  * @returns
  */
 export function createLoader(
     source: VectorSource<FeatureLike>,
     url: string,
-    srs = 'EPSG:4326',
     strategy: LoadingStrategy = all,
     clear = false,
-    headers: HeadersInit = {},
-    renderFeature = false,
+    deserializerOptions: DeserializerOptions = {},
 ): FeatureLoader<FeatureLike> {
     return async (extent, _resolution, projection, success, failure) => {
         try {
             if (clear) source.clear();
-            const code = projection.getCode();
+            deserializerOptions.dataProjection = 'EPSG:4326';
+            deserializerOptions.featureProjection = projection.getCode();
             const features: FeatureLike[] = [];
             let it: AsyncGenerator<FeatureLike> | undefined;
             if (strategy === all) {
-                const response = await fetch(url, { headers });
-                it = deserialize(
-                    response.body as ReadableStream,
-                    undefined,
-                    undefined,
-                    false,
-                    headers,
-                    renderFeature,
-                    srs,
-                    code,
-                );
+                const response = await fetch(url, { headers: deserializerOptions.headers });
+                it = deserialize(response.body as ReadableStream, undefined, deserializerOptions);
             } else {
-                const rect = extentToRect(extent, code, srs);
-                it = deserialize(url, rect, undefined, false, headers, renderFeature, srs, code);
+                const rect = extentToRect(
+                    extent,
+                    deserializerOptions.featureProjection,
+                    deserializerOptions.dataProjection,
+                );
+                it = deserialize(url, rect, deserializerOptions);
             }
             for await (const feature of it) {
                 features.push(feature);
@@ -131,23 +137,28 @@ export const tileUrlFunction = (tileCoord: TileCoord) => JSON.stringify(tileCoor
 /**
  * Intended to be used with VectorTileSource and setTileLoadFunction to set up
  * a single file FlatGeobuf as a source.
+ * @param source
  * @param url
+ * @param deserializerOptions
  * @returns
  */
 export function createTileLoadFunction(
     source: VectorTileSource,
     url: string,
-    srs = 'EPSG:4326',
-    headers: HeadersInit = {},
-    renderFeature = false,
+    deserializerOptions: DeserializerOptions = {},
 ) {
     const projection = source.getProjection();
-    const code = projection?.getCode() ?? 'EPSG:3857';
+    deserializerOptions.dataProjection = 'EPSG:4326';
+    deserializerOptions.featureProjection = projection?.getCode() ?? 'EPSG:3857';
     const tileLoadFunction: LoadFunction = (tile) => {
         const vectorTile = tile as VectorTile<FeatureLike>;
         const loader: FeatureLoader = async (extent) => {
-            const rect = extentToRect(extent, code, srs);
-            const it = deserialize(url, rect, undefined, false, headers, renderFeature, srs, code);
+            const rect = extentToRect(
+                extent,
+                deserializerOptions.featureProjection,
+                deserializerOptions.dataProjection,
+            );
+            const it = deserialize(url, rect, deserializerOptions);
             const features: FeatureLike[] = [];
             for await (const feature of it) features.push(feature);
             vectorTile.setFeatures(features);

--- a/vite/src/ol.ts
+++ b/vite/src/ol.ts
@@ -2,7 +2,6 @@ import TileLayer from 'ol/layer/Tile.js';
 import VectorLayer from 'ol/layer/Vector.js';
 import { bbox } from 'ol/loadingstrategy';
 import Map from 'ol/Map.js';
-// import RenderFeature from "ol/render/Feature.js";
 import OSM from 'ol/source/OSM.js';
 import VectorSource from 'ol/source/Vector.js';
 import View from 'ol/View.js';
@@ -10,6 +9,12 @@ import { createLoader } from '../../src/ts/ol';
 
 const url = '/data/countries.fgb';
 const source = new VectorSource({ strategy: bbox });
+
+// To test renderFeatures.
+// source.setLoader(createLoader(source, url, undefined, undefined, {
+//     renderFeature: true
+// }));
+
 source.setLoader(createLoader(source, url));
 
 new Map({


### PR DESCRIPTION
For #490 

Variante of #491 where, instead of introduce a new class, we only group parameters used by the deserialization to a single "DeserializeOptions" option and new interface.