### PR TITLE
Add Generalized FlatGeobuf Viewer link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ FlatGeobuf is open source under the [BSD 2-Clause License](https://tldrlegal.com
 * [OpenLayers example](https://flatgeobuf.org/examples/openlayers)
 * [Leaflet example](https://flatgeobuf.org/examples/leaflet)
 * [MapLibre/Mapbox example](https://flatgeobuf.org/examples/maplibre)
+* [Generalized FlatGeobuf Viewer](https://colton.place/flatgeobuf-viewer/)
 
 ## Specification
 


### PR DESCRIPTION
Adds https://colton.place/flatgeobuf-viewer/ to the examples section as discussed here: https://github.com/flatgeobuf/flatgeobuf/discussions/506#discussioncomment-17826066

I have kept the similar pattern of the other examples of just a label on the link and no extra description. Happy to tweak this label as preferred! I figure `Generalized FlatGeobuf Viewer` calls out why it is distinct from the other examples but still keeps the label fairly brief.