### PR TITLE
Fix C++ packed R-tree endian handling

### DIFF
--- a/src/cpp/packedrtree.cpp
+++ b/src/cpp/packedrtree.cpp
@@ -29,12 +29,6 @@
 // NOTE: The upstream of this file is in
 // https://github.com/bjornharrtell/flatgeobuf/tree/master/src/cpp
 
-#ifdef GDAL_COMPILATION
-#include "cpl_port.h"
-#else
-#define CPL_IS_LSB 1
-#endif
-
 #include "packedrtree.h"
 
 #include <algorithm>
@@ -45,6 +39,19 @@
 
 namespace FlatGeobuf
 {
+
+#if !FLATBUFFERS_LITTLEENDIAN
+static inline NodeItem endianSwap(const NodeItem &nodeItem)
+{
+    NodeItem converted = nodeItem;
+    converted.minX = flatbuffers::EndianScalar(converted.minX);
+    converted.minY = flatbuffers::EndianScalar(converted.minY);
+    converted.maxX = flatbuffers::EndianScalar(converted.maxX);
+    converted.maxY = flatbuffers::EndianScalar(converted.maxY);
+    converted.offset = flatbuffers::EndianScalar(converted.offset);
+    return converted;
+}
+#endif
 
 const NodeItem &NodeItem::expand(const NodeItem &r)
 {
@@ -285,6 +292,9 @@ void PackedRTree::fromData(const void *data)
     for (uint64_t i = 0; i < _numNodes; i++)
     {
         NodeItem n = *pn++;
+#if !FLATBUFFERS_LITTLEENDIAN
+        n = endianSwap(n);
+#endif
         _nodeItems[i] = n;
         _extent.expand(n);
     }
@@ -389,15 +399,9 @@ std::vector<SearchResultItem> PackedRTree::streamSearch(
         uint64_t length = end - nodeIndex;
         readNode(nodesBuf, static_cast<size_t>(nodeIndex * sizeof(NodeItem)),
                  static_cast<size_t>(length * sizeof(NodeItem)));
-#if !CPL_IS_LSB
+#if !FLATBUFFERS_LITTLEENDIAN
         for (size_t i = 0; i < static_cast<size_t>(length); i++)
-        {
-            CPL_LSBPTR64(&nodeItems[i].minX);
-            CPL_LSBPTR64(&nodeItems[i].minY);
-            CPL_LSBPTR64(&nodeItems[i].maxX);
-            CPL_LSBPTR64(&nodeItems[i].maxY);
-            CPL_LSBPTR64(&nodeItems[i].offset);
-        }
+            nodeItems[i] = endianSwap(nodeItems[i]);
 #endif
         // search through child nodes
         for (uint64_t pos = nodeIndex; pos < end; pos++)
@@ -446,27 +450,15 @@ uint64_t PackedRTree::size(const uint64_t numItems, const uint16_t nodeSize)
 void PackedRTree::streamWrite(
     const std::function<void(uint8_t *, size_t)> &writeData)
 {
-#if !CPL_IS_LSB
+#if !FLATBUFFERS_LITTLEENDIAN
+    std::vector<NodeItem> nodeItems(_nodeItems, _nodeItems + _numNodes);
     for (size_t i = 0; i < static_cast<size_t>(_numNodes); i++)
-    {
-        CPL_LSBPTR64(&_nodeItems[i].minX);
-        CPL_LSBPTR64(&_nodeItems[i].minY);
-        CPL_LSBPTR64(&_nodeItems[i].maxX);
-        CPL_LSBPTR64(&_nodeItems[i].maxY);
-        CPL_LSBPTR64(&_nodeItems[i].offset);
-    }
-#endif
+        nodeItems[i] = endianSwap(nodeItems[i]);
+    writeData(reinterpret_cast<uint8_t *>(nodeItems.data()),
+              static_cast<size_t>(_numNodes * sizeof(NodeItem)));
+#else
     writeData(reinterpret_cast<uint8_t *>(_nodeItems),
               static_cast<size_t>(_numNodes * sizeof(NodeItem)));
-#if !CPL_IS_LSB
-    for (size_t i = 0; i < static_cast<size_t>(_numNodes); i++)
-    {
-        CPL_LSBPTR64(&_nodeItems[i].minX);
-        CPL_LSBPTR64(&_nodeItems[i].minY);
-        CPL_LSBPTR64(&_nodeItems[i].maxX);
-        CPL_LSBPTR64(&_nodeItems[i].maxY);
-        CPL_LSBPTR64(&_nodeItems[i].offset);
-    }
 #endif
 }
 


### PR DESCRIPTION
The standalone C++ implementation hardcodes non-GDAL builds as little-endian:

```cpp
#ifndef GDAL_COMPILATION
#define CPL_IS_LSB 1
#endif
```

That leaves the existing byte-swap paths inactive on big-endian hosts unless the file is compiled inside GDAL.

This switches the C++ implementation to FlatBuffers' own `FLATBUFFERS_LITTLEENDIAN` / `EndianScalar` helpers, which are already available through `packedrtree.h`. It also avoids mutating `_nodeItems` in-place during `streamWrite()` on big-endian builds by writing from a converted copy instead.

This was found while carrying the downstream PostGIS vendored FlatGeobuf copy on big-endian CI.

Validation:
- `cd src/cpp && clang++ -std=c++14 -Wall -Wfloat-conversion -Wmissing-declarations -fsanitize=float-divide-by-zero -g -I./ -I./include -c packedrtree.cpp -o build/packedrtree-little.o`
- `cd src/cpp && clang++ -std=c++14 -Wall -Wfloat-conversion -Wmissing-declarations -fsanitize=float-divide-by-zero -g -I./ -I./include -UFLATBUFFERS_LITTLEENDIAN -DFLATBUFFERS_LITTLEENDIAN=0 -c packedrtree.cpp -o build/packedrtree-forced-big.o`

I also tried the full C++ test target after `script/getcppdeps.sh`, but it currently fails before reaching these changes because the fetched RapidJSON 1.1.0 headers do not compile with the host compiler (`GenericStringRef::length` is const but assigned in `operator=`).
