### PR TITLE
fix(go): accept flatgeobuf files with a differing magic-byte patch version

### DIFF
--- a/src/go/flatgeobuf.go
+++ b/src/go/flatgeobuf.go
@@ -176,9 +176,16 @@ func (fgb *FlatGeoBuf) mmapOrLoadFile(path string, behavior Behavior) error {
 }
 
 func (fgb *FlatGeoBuf) setup(behavior Behavior) error {
-	// Check magic bytes.
-	if len(fgb.data) < len(writer.MagicBytes) ||
-		!bytes.Equal(fgb.data[:len(writer.MagicBytes)], writer.MagicBytes) {
+	// Check magic bytes. The last byte is the spec patch version, which the
+	// other implementations (Rust, Java) and the shared spec decision in PR
+	// #146 deliberately ignore. GDAL/geopandas write it as 0x01, so comparing
+	// the full 8 bytes would reject valid files. Match only "fgb" (bytes 0-2),
+	// the major version (byte 3), and "fgb" (bytes 4-6).
+	mb := writer.MagicBytes
+	if len(fgb.data) < len(mb) ||
+		!bytes.Equal(fgb.data[0:3], mb[0:3]) || // "fgb"
+		fgb.data[3] != mb[3] || // major version
+		!bytes.Equal(fgb.data[4:7], mb[4:7]) { // "fgb" (byte 7 patch version ignored)
 		return fmt.Errorf("not a flatgeobuf file: invalid magic bytes")
 	}
 

--- a/src/go/flatgeobuf_test.go
+++ b/src/go/flatgeobuf_test.go
@@ -3,6 +3,8 @@ package flatgeobuf
 import (
 	"bytes"
 	"encoding/binary"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -60,6 +62,28 @@ func TestFlatGeoBuf_LoadIndex(t *testing.T) {
 
 	if len(features) != 2 {
 		t.Errorf("expected 2 features, got: %v", len(features))
+	}
+}
+
+func TestFlatGeoBuf_LenientPatchVersion(t *testing.T) {
+	// Files written by GDAL/geopandas carry a patch version of 0x01 in the
+	// last magic byte. The reader must accept it, matching the Rust and Java
+	// implementations and the shared spec decision in PR #146.
+	data, err := os.ReadFile("./poly_landmarks.fgb")
+	if err != nil {
+		t.Fatalf("failed to read fixture: %v", err)
+	}
+
+	// Flip the patch version byte (index 7) from 0x00 to 0x01.
+	data[7] = 0x01
+
+	path := filepath.Join(t.TempDir(), "patch_version.fgb")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+
+	if _, err := New(path); err != nil {
+		t.Errorf("expected nil error for patch version 0x01, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
Fixes #480

## Problem
The Go bindings reject valid FlatGeobuf files written by GDAL/geopandas with "not a flatgeobuf file: invalid magic bytes".

## Root cause
`(*FlatGeoBuf).setup()` in `src/go/flatgeobuf.go` compares the full 8-byte magic sequence against `writer.MagicBytes` (`{0x66,0x67,0x62,0x03,0x66,0x67,0x62,0x00}`). The last byte is the spec *patch* version. GDAL and geopandas write it as `0x01`, so the strict 8-byte `bytes.Equal` fails for every file they produce.

The other implementations deliberately ignore the patch byte: Rust's `check_magic_bytes` checks bytes `[0..3]`, `[4..7]` and `[3] <= VERSION`, and Java checks only the first four bytes. This leniency was the explicit, repo-wide decision in merged PR #146; the Go bindings were added later (PR #303) and missed it. Go was the only strict reader.

## Fix
Mirror the other implementations: match `"fgb"` (bytes 0-2), the major version (byte 3), and `"fgb"` (bytes 4-6), and ignore the patch version byte (byte 7). The error string is unchanged.

## Testing
Added `TestFlatGeoBuf_LenientPatchVersion`, which reads the existing `poly_landmarks.fgb` fixture, flips its patch byte to `0x01`, writes it to a temp file, and asserts `New(path)` succeeds.

- Before the fix: the new test fails with the "invalid magic bytes" error.
- After the fix: it passes.
- `go test ./...` (full src/go), `go vet ./...`, and `gofmt` are all clean.

---
This change was prepared with AI assistance and reviewed by the author.