### PR TITLE
fix(go): return an error instead of panicking on a truncated header

### DIFF
--- a/src/go/flatgeobuf.go
+++ b/src/go/flatgeobuf.go
@@ -192,8 +192,20 @@ func (fgb *FlatGeoBuf) setup(behavior Behavior) error {
 	// Increment offset past magic bytes.
 	offset := len(writer.MagicBytes)
 
+	// Make sure the header size prefix is present before reading it, otherwise
+	// truncated input causes an out-of-bounds panic instead of an error.
+	if len(fgb.data) < offset+flatbuffers.SizeUOffsetT {
+		return fmt.Errorf("not a flatgeobuf file: truncated header size")
+	}
+
 	// Read header size.
 	headerSize := int(flatbuffers.GetUOffsetT(fgb.data[offset:]))
+
+	// Make sure the full header is present before handing it to flatbuffers,
+	// which does not bounds-check the buffer it is given.
+	if headerSize < 0 || offset+flatbuffers.SizeUOffsetT+headerSize > len(fgb.data) {
+		return fmt.Errorf("invalid flatgeobuf header: header size %d exceeds data", headerSize)
+	}
 
 	// Read header ignoring the size
 	fgb.header = flattypes.GetSizePrefixedRootAsHeader(fgb.data, flatbuffers.UOffsetT(offset))

--- a/src/go/robustness_test.go
+++ b/src/go/robustness_test.go
@@ -1,0 +1,40 @@
+package flatgeobuf
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/flatgeobuf/flatgeobuf/src/go/writer"
+)
+
+// TestNewWithData_TruncatedHeader ensures that truncated input carrying only a
+// valid magic-byte prefix is rejected with an error instead of panicking with
+// an out-of-bounds slice access while reading the header size prefix.
+func TestNewWithData_TruncatedHeader(t *testing.T) {
+	cases := map[string][]byte{
+		"magic only":              writer.MagicBytes,
+		"magic plus partial size": append(append([]byte{}, writer.MagicBytes...), 0x00, 0x00),
+	}
+
+	for name, data := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := NewWithData(data); err == nil {
+				t.Fatalf("expected error for truncated input, got nil")
+			}
+		})
+	}
+}
+
+// TestNewWithData_HeaderSizeExceedsData ensures that a header size prefix
+// claiming more bytes than the buffer contains is rejected with an error
+// instead of letting flatbuffers read out of bounds.
+func TestNewWithData_HeaderSizeExceedsData(t *testing.T) {
+	data := append([]byte{}, writer.MagicBytes...)
+	size := make([]byte, 4)
+	binary.LittleEndian.PutUint32(size, 1<<20) // claim a 1 MiB header
+	data = append(data, size...)
+
+	if _, err := NewWithData(data); err == nil {
+		t.Fatalf("expected error for oversized header size, got nil")
+	}
+}


### PR DESCRIPTION
Reading a truncated flatgeobuf file through the Go reader's main entry points (`New`, `NewWithData`) panics instead of returning an error, because `setup()` reads the header size prefix and hands the buffer to flatbuffers without first checking that the bytes are actually present.

### Failure mode
A file that contains only the 8 magic bytes (or those bytes plus a partial/oversized size prefix) reaches `setup()`, which does `flatbuffers.GetUOffsetT(fgb.data[offset:])` at `offset == 8`. With no bytes left, flatbuffers reads out of bounds:

```
panic: runtime error: index out of range [3] with length 0
  github.com/google/flatbuffers/go.GetUint32(...)
  .../src/go.(*FlatGeoBuf).setup(...) flatgeobuf.go:196
  .../src/go.NewWithData(...) flatgeobuf.go:75
```

Since `New`/`NewWithData` are the documented way to open a file, any caller feeding untrusted or truncated input can be crashed.

### Repro
```go
_, err := flatgeobuf.NewWithData([]byte{0x66,0x67,0x62,0x03,0x66,0x67,0x62,0x00}) // 8 magic bytes
// panics before this fix
```

### Fix
Two bounds checks in `setup()` before touching flatbuffers:
- ensure the 4-byte header size prefix is present, and
- ensure the declared header size fits within the remaining data.

Both cases now return a descriptive error. Valid files are unaffected (the full existing suite passes), and the post-header `offset` is now guaranteed in-bounds for the index/features reads that follow.

### Scope
This addresses the truncated/short-buffer panics in the header region of `setup()`. It does not attempt to fully verify a well-formed-but-malformed flatbuffer body (that would need a flatbuffers verifier) or harden the packed R-tree index reader; those are separate concerns.

### Tests
Added `src/go/robustness_test.go` covering the magic-only, partial-size-prefix, and oversized-header-size cases. Fails (panics) before the change, passes after; `go test ./...`, `gofmt`, and `go vet` are clean.